### PR TITLE
Add bulk delete emails functionality with optional expunge

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -213,7 +213,7 @@ export class ImapService {
   async deleteEmail(accountId: string, folderName: string, uid: number): Promise<void> {
     await this.selectFolder(accountId, folderName);
     const connection = this.getConnection(accountId);
-    
+
     return new Promise((resolve, reject) => {
       connection.addFlags(uid, '\\Deleted', (err: Error) => {
         if (err) {
@@ -224,6 +224,33 @@ export class ImapService {
           if (err) reject(err);
           else resolve();
         });
+      });
+    });
+  }
+
+  async bulkDeleteEmails(accountId: string, folderName: string, uids: number[], expunge: boolean = false): Promise<void> {
+    if (uids.length === 0) {
+      return;
+    }
+
+    await this.selectFolder(accountId, folderName);
+    const connection = this.getConnection(accountId);
+
+    return new Promise((resolve, reject) => {
+      connection.addFlags(uids, '\\Deleted', (err: Error) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        if (expunge) {
+          connection.expunge((err: Error) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        } else {
+          resolve();
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary

Added bulkDeleteEmails method to ImapService for efficient deletion of multiple emails. Created imap_bulk_delete_emails MCP tool for bulk email deletion with optional expunge parameter.

## Features

### New Service Method: bulkDeleteEmails
- Accepts an array of UIDs for bulk deletion operations
- Marks emails with \Deleted flag
- Optional expunge parameter controls permanent deletion (default: false)
- Handles empty UID arrays gracefully
- Efficient for deleting hundreds or thousands of emails

### New MCP Tool: imap_bulk_delete_emails

Parameters:
- accountId (string): Account ID
- folder (string): Folder name (default: INBOX)
- uids (array of numbers): Email UIDs to delete
- expunge (boolean): Permanently expunge deleted emails (default: false)

Response includes success status, deletedCount, expunged flag, and message.

## Use Cases

1. Mark as deleted without expunging (default) - allows recovery
2. Permanently delete emails by setting expunge: true

## Technical Details

- Leverages node-imap library's native support for bulk flag operations
- No changes to existing single delete functionality
- TypeScript type-safe implementation
- Follows existing code patterns and conventions

## Testing

- Build passes successfully
- No breaking changes to existing functionality
- TypeScript compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)