### PR TITLE
Add launchctl setup documentation for macOS

### DIFF
--- a/docs/launchctl-setup.md
+++ b/docs/launchctl-setup.md
@@ -1,0 +1,225 @@
+# Running IMAP MCP Server with launchctl (macOS)
+
+This guide explains how to set up the IMAP MCP server to run automatically as a launchd service on macOS using launchctl.
+
+## Overview
+
+Using launchctl offers several advantages:
+- **Auto-start**: Service starts automatically when you log in
+- **Auto-restart**: Service automatically restarts if it crashes
+- **Background operation**: Runs in the background without terminal windows
+- **Log management**: Centralized logging to dedicated log files
+- **Resource management**: Better integration with macOS system services
+
+## Prerequisites
+
+- macOS system
+- IMAP MCP Server installed and built (`npm install && npm run build`)
+- Node.js and npm installed
+
+## Setup Instructions
+
+### 1. Create the LaunchAgent Directory
+
+```bash
+mkdir -p ~/Library/LaunchAgents
+```
+
+### 2. Create the Property List (plist) File
+
+Create a file at `~/Library/LaunchAgents/com.imap-mcp-server.plist` using the sample provided in this repository:
+
+```bash
+cp examples/com.imap-mcp-server.plist ~/Library/LaunchAgents/
+```
+
+Or create it manually using the sample template below.
+
+### 3. Edit the plist File
+
+Update the following paths in the plist file to match your setup:
+
+- **WorkingDirectory**: Path to your IMAP MCP server installation
+- **PATH**: Ensure it includes the directory where your `node` and `npm` binaries are located
+- **StandardOutPath**: Log file location (optional)
+- **StandardErrorPath**: Error log file location (optional)
+
+Common Node.js binary locations:
+- Homebrew: `/opt/homebrew/bin` (Apple Silicon) or `/usr/local/bin` (Intel)
+- MacPorts: `/opt/local/bin`
+- nvm: `/Users/YOUR_USERNAME/.nvm/versions/node/VERSION/bin`
+
+### 4. Create Log Directory
+
+```bash
+mkdir -p ~/Library/Logs
+```
+
+### 5. Load the Service
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.imap-mcp-server.plist
+```
+
+The service will start automatically and continue running in the background.
+
+## Managing the Service
+
+### Check Service Status
+
+```bash
+launchctl list | grep imap-mcp-server
+```
+
+Output format: `PID Status Label`
+- If PID is shown, the service is running
+- Status code (usually 0 for success)
+
+### Start the Service
+
+```bash
+launchctl start com.imap-mcp-server
+```
+
+### Stop the Service
+
+```bash
+launchctl stop com.imap-mcp-server
+```
+
+### Restart the Service
+
+After making code changes, rebuild and restart:
+
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.imap-mcp-server
+```
+
+The `-k` flag kills the existing process before restarting.
+
+### Unload the Service
+
+To completely disable the service:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.imap-mcp-server.plist
+```
+
+### Reload After Configuration Changes
+
+If you modify the plist file:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.imap-mcp-server.plist
+launchctl load ~/Library/LaunchAgents/com.imap-mcp-server.plist
+```
+
+## Viewing Logs
+
+### Standard Output Log
+
+```bash
+tail -f ~/Library/Logs/imap-mcp-server.log
+```
+
+### Error Log
+
+```bash
+tail -f ~/Library/Logs/imap-mcp-server.error.log
+```
+
+### View Recent Logs
+
+```bash
+# Last 50 lines
+tail -n 50 ~/Library/Logs/imap-mcp-server.log
+
+# Last 50 error lines
+tail -n 50 ~/Library/Logs/imap-mcp-server.error.log
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+1. Check the logs for errors:
+   ```bash
+   cat ~/Library/Logs/imap-mcp-server.error.log
+   ```
+
+2. Verify the plist file syntax:
+   ```bash
+   plutil -lint ~/Library/LaunchAgents/com.imap-mcp-server.plist
+   ```
+
+3. Check PATH and WorkingDirectory in the plist file
+
+4. Ensure the project is built:
+   ```bash
+   cd /path/to/imap-mcp-server
+   npm run build
+   ```
+
+### Service Keeps Crashing
+
+1. Check error logs for Node.js errors
+2. Try running manually first to diagnose:
+   ```bash
+   cd /path/to/imap-mcp-server
+   npm run web
+   ```
+3. Verify all dependencies are installed: `npm install`
+
+### Permission Issues
+
+Ensure the plist file has correct permissions:
+```bash
+chmod 644 ~/Library/LaunchAgents/com.imap-mcp-server.plist
+```
+
+### Changes Not Taking Effect
+
+After code changes, always rebuild and restart:
+```bash
+npm run build
+launchctl kickstart -k gui/$(id -u)/com.imap-mcp-server
+```
+
+## Alternative: Running Stdio Mode
+
+The sample plist runs the web server mode (`npm run web`). To run stdio mode instead (for direct MCP integration), modify the ProgramArguments:
+
+```xml
+<key>ProgramArguments</key>
+<array>
+    <string>/opt/local/bin/npm</string>
+    <string>start</string>
+</array>
+```
+
+Note: Stdio mode is typically used when Claude Desktop or another MCP client manages the server lifecycle directly.
+
+## Uninstalling
+
+To completely remove the launchd service:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.imap-mcp-server.plist
+rm ~/Library/LaunchAgents/com.imap-mcp-server.plist
+rm ~/Library/Logs/imap-mcp-server.log
+rm ~/Library/Logs/imap-mcp-server.error.log
+```
+
+## Security Considerations
+
+- The service runs with your user permissions
+- Account credentials are stored encrypted in `~/.imap-mcp/accounts.json`
+- Logs may contain email metadata; ensure proper file permissions
+- Consider log rotation for long-running services
+
+## Additional Resources
+
+- [launchd.info](https://www.launchd.info/) - Comprehensive launchd documentation
+- [Apple Developer - launchd](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html)
+- [MCP Documentation](https://modelcontextprotocol.io/)

--- a/examples/com.imap-mcp-server.plist
+++ b/examples/com.imap-mcp-server.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Service identifier - must be unique -->
+    <key>Label</key>
+    <string>com.imap-mcp-server</string>
+
+    <!-- Command to run - Update npm path based on your installation -->
+    <key>ProgramArguments</key>
+    <array>
+        <!-- Update this path to match your npm location -->
+        <!-- Homebrew (Intel): /usr/local/bin/npm -->
+        <!-- Homebrew (Apple Silicon): /opt/homebrew/bin/npm -->
+        <!-- MacPorts: /opt/local/bin/npm -->
+        <!-- nvm: /Users/YOUR_USERNAME/.nvm/versions/node/vX.X.X/bin/npm -->
+        <string>/usr/local/bin/npm</string>
+        <string>run</string>
+        <!-- Use 'web' for HTTP server mode or 'start' for stdio mode -->
+        <string>web</string>
+    </array>
+
+    <!-- Working directory - Update to your installation path -->
+    <key>WorkingDirectory</key>
+    <string>/Users/YOUR_USERNAME/Projects/imap-mcp-server</string>
+
+    <!-- Start service when user logs in -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart service if it crashes -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Optional: Throttle restart attempts if service crashes repeatedly -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <!-- Log files - Update paths as needed -->
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/imap-mcp-server.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/Library/Logs/imap-mcp-server.error.log</string>
+
+    <!-- Environment variables -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- PATH should include node and npm binary locations -->
+        <!-- Update based on your Node.js installation -->
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+
+        <!-- Optional: Set NODE_ENV -->
+        <key>NODE_ENV</key>
+        <string>production</string>
+    </dict>
+
+    <!-- Optional: Set process priority (nice value, -20 to 20, lower = higher priority) -->
+    <key>Nice</key>
+    <integer>0</integer>
+
+    <!-- Optional: Limit CPU usage (0-100, percentage) -->
+    <!-- <key>ProcessType</key>
+    <string>Background</string> -->
+
+    <!-- Optional: Run service only when network is available -->
+    <!-- <key>LaunchOnlyOnce</key>
+    <false/> -->
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Added comprehensive documentation and sample configuration for running the IMAP MCP server as a macOS launchd service using launchctl.

## New Files

### Documentation
- **docs/launchctl-setup.md**: Complete setup guide including:
  - Installation and configuration instructions
  - Service management commands (start/stop/restart)
  - Log viewing and monitoring
  - Troubleshooting common issues
  - Security considerations
  - Uninstallation steps

### Sample Configuration
- **examples/com.imap-mcp-server.plist**: Sample launchd property list with:
  - Detailed comments for customization
  - Auto-start on login configuration
  - Auto-restart on crash
  - Log file configuration
  - Environment variable setup
  - Common path options for different Node.js installations

## Benefits

Running as a launchd service provides:
- ✅ Automatic startup when user logs in
- ✅ Automatic restart if the service crashes
- ✅ Background operation without terminal windows
- ✅ Centralized log management
- ✅ Better integration with macOS system services

## Usage Example

After following the guide, users can:
```bash
# Install the service
cp examples/com.imap-mcp-server.plist ~/Library/LaunchAgents/
launchctl load ~/Library/LaunchAgents/com.imap-mcp-server.plist

# Restart after code changes
npm run build
launchctl kickstart -k gui/$(id -u)/com.imap-mcp-server
```

## Testing

- ✅ Documentation reviewed for clarity and accuracy
- ✅ Sample plist includes comprehensive configuration options
- ✅ Tested on macOS with both Intel and Apple Silicon paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)