### PR TITLE
feat: allow IMAP username different from email address

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -133,6 +133,11 @@
                                             <input type="number" id="imapPort" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
                                         </div>
                                     </div>
+                                    <div class="mt-3">
+                                        <label class="block text-sm font-medium text-gray-700 mb-2">IMAP Username</label>
+                                        <input type="text" id="imapUsername" class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500" placeholder="Leave blank to use email address">
+                                        <p class="text-xs text-gray-500 mt-1">Only set this if your IMAP username is different from your email address.</p>
+                                    </div>
                                 </div>
                                 <div>
                                     <div class="flex items-center justify-between mb-2">

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -133,6 +133,7 @@ function goToStep(step) {
 async function handleAccountUpdate(e) {
     e.preventDefault();
     
+    const imapUsername = document.getElementById('imapUsername').value.trim();
     const accountData = {
         name: document.getElementById('accountName').value,
         email: document.getElementById('email').value,
@@ -140,7 +141,8 @@ async function handleAccountUpdate(e) {
         host: document.getElementById('imapHost').value,
         port: parseInt(document.getElementById('imapPort').value),
         tls: selectedProvider?.imapSecurity !== 'STARTTLS',
-        saveToSent: document.getElementById('saveToSent').checked
+        saveToSent: document.getElementById('saveToSent').checked,
+        imapUsername: imapUsername || undefined
     };
 
     // Only include password if it was changed
@@ -165,6 +167,7 @@ async function handleAccountSubmit(e) {
         return;
     }
 
+    const imapUsername = document.getElementById('imapUsername').value.trim();
     const accountData = {
         name: document.getElementById('accountName').value,
         email: document.getElementById('email').value,
@@ -172,7 +175,8 @@ async function handleAccountSubmit(e) {
         host: document.getElementById('imapHost').value,
         port: parseInt(document.getElementById('imapPort').value),
         tls: selectedProvider?.imapSecurity !== 'STARTTLS',
-        saveToSent: document.getElementById('saveToSent').checked
+        saveToSent: document.getElementById('saveToSent').checked,
+        imapUsername: imapUsername || undefined
     };
 
     // Add SMTP configuration if enabled
@@ -388,11 +392,12 @@ async function editAccount(accountId) {
 
         // Pre-fill form with account data
         document.getElementById('accountName').value = account.name || '';
-        document.getElementById('email').value = account.user || '';
+        document.getElementById('email').value = account.email || account.user || '';
         document.getElementById('password').value = ''; // Don't pre-fill password
         document.getElementById('password').placeholder = 'Leave blank to keep current password';
         document.getElementById('imapHost').value = account.host || '';
         document.getElementById('imapPort').value = account.port || 993;
+        document.getElementById('imapUsername').value = account.email ? account.user : '';
         document.getElementById('saveToSent').checked = account.saveToSent !== false;
 
         // Pre-fill SMTP settings if available
@@ -477,13 +482,15 @@ async function testCurrentSettings() {
     document.getElementById('inlineTestError').classList.add('hidden');
     
     // Get current form values
+    const imapUsername = document.getElementById('imapUsername').value.trim();
     const accountData = {
         name: document.getElementById('accountName').value,
         email: document.getElementById('email').value,
         password: document.getElementById('password').value,
         host: document.getElementById('imapHost').value,
         port: parseInt(document.getElementById('imapPort').value),
-        tls: selectedProvider?.imapSecurity !== 'STARTTLS'
+        tls: selectedProvider?.imapSecurity !== 'STARTTLS',
+        imapUsername: imapUsername || undefined
     };
     
     // If editing and no password provided, we can't test

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -95,7 +95,7 @@ export class SmtpService {
       const transporter = await this.createTransporter(account);
 
       const mailOptions: nodemailer.SendMailOptions = {
-        from: email.from || account.user,
+        from: email.from || account.email || account.user,
         to: email.to,
         cc: email.cc,
         bcc: email.bcc,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -443,7 +443,7 @@ export function emailTools(
     }
 
     const emailComposer = {
-      from: account.user,
+      from: account.email || account.user,
       to,
       subject,
       text,
@@ -511,11 +511,12 @@ export function emailTools(
     // Prepare reply
     const recipients = [originalEmail.from];
     if (replyAll) {
-      recipients.push(...originalEmail.to.filter(addr => addr !== account.user));
+      const accountEmail = account.email || account.user;
+      recipients.push(...originalEmail.to.filter(addr => addr !== accountEmail));
     }
 
     const emailComposer = {
-      from: account.user,
+      from: account.email || account.user,
       to: recipients,
       subject: originalEmail.subject.startsWith('Re: ') ? originalEmail.subject : `Re: ${originalEmail.subject}`,
       text,
@@ -577,7 +578,7 @@ export function emailTools(
     const forwardHeader = `\n\n---------- Forwarded message ----------\nFrom: ${originalEmail.from}\nDate: ${originalEmail.date.toLocaleString()}\nSubject: ${originalEmail.subject}\nTo: ${originalEmail.to.join(', ')}\n\n`;
     
     const emailComposer = {
-      from: account.user,
+      from: account.email || account.user,
       to,
       subject: originalEmail.subject.startsWith('Fwd: ') ? originalEmail.subject : `Fwd: ${originalEmail.subject}`,
       text: (text || '') + forwardHeader + (originalEmail.textContent || ''),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface ImapAccount {
   user: string;
   password: string;
   tls: boolean;
+  email?: string;
   authTimeout?: number;
   connTimeout?: number;
   keepalive?: boolean;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -53,7 +53,7 @@ export class WebUIServer {
     // Add new account
     this.app.post('/api/accounts', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp } = req.body;
+        const { name, email, password, host, port, tls, smtp, imapUsername } = req.body;
         
         // Auto-detect provider if not specified
         let imapHost = host;
@@ -73,9 +73,10 @@ export class WebUIServer {
           name: name || email,
           host: imapHost,
           port: imapPort || 993,
-          user: email,
+          user: imapUsername || email,
           password,
           tls: useTls !== false,
+          ...(imapUsername ? { email } : {}),
           smtp: smtp || undefined,
         });
         
@@ -91,15 +92,15 @@ export class WebUIServer {
     // Test connection
     this.app.post('/api/test-connection', async (req, res) => {
       try {
-        const { email, password, host, port, tls } = req.body;
-        
+        const { email, password, host, port, tls, imapUsername } = req.body;
+
         // Create temporary account for testing
         const testAccount: ImapAccount = {
           id: 'test-' + Date.now(),
           name: 'Test',
           host: host || 'imap.gmail.com',
           port: port || 993,
-          user: email,
+          user: imapUsername || email,
           password,
           tls: tls !== false,
         };
@@ -141,11 +142,17 @@ export class WebUIServer {
     // Update account
     this.app.put('/api/accounts/:id', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp, saveToSent } = req.body;
+        const { name, email, password, host, port, tls, smtp, saveToSent, imapUsername } = req.body;
 
         const updates: any = {};
         if (name !== undefined) updates.name = name;
-        if (email !== undefined) updates.user = email;
+        if (imapUsername) {
+          updates.user = imapUsername;
+          if (email !== undefined) updates.email = email;
+        } else if (email !== undefined) {
+          updates.user = email;
+          updates.email = undefined;
+        }
         if (password !== undefined) updates.password = password;
         if (host !== undefined) updates.host = host;
         if (port !== undefined) updates.port = port;


### PR DESCRIPTION
## Summary
- Adds optional **IMAP Username** field in Advanced Settings of the Web UI
- Adds `email` field to `ImapAccount` type to separate auth username from email address
- When IMAP username is set, it's used for authentication while the email address is used for `from` headers in sent emails
- Backwards compatible: existing accounts where username = email continue to work unchanged

Closes #43

## Test plan
- [ ] Add account with Custom provider where IMAP username differs from email
- [ ] Verify IMAP authentication uses the custom username
- [ ] Verify sent emails use the email address (not username) in `from` field
- [ ] Edit existing account and set custom IMAP username
- [ ] Verify existing accounts without custom username still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)