### PR TITLE
fix: gate IMAP-disabled provider hints on matching errors

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -60,25 +60,26 @@ function enrichConnectionError(error: unknown, host: string): string {
   // Check if the error message already indicates IMAP is disabled
   const looksLikeImapDisabled = IMAP_DISABLED_PATTERNS.some(pattern => pattern.test(originalMessage));
 
+  if (!looksLikeImapDisabled) {
+    return originalMessage;
+  }
+
   const matchedProvider = PROVIDERS_REQUIRING_IMAP_ENABLE.find(p => p.pattern.test(host));
 
-  if (looksLikeImapDisabled || matchedProvider) {
-    if (matchedProvider) {
-      return (
-        `${originalMessage}\n\n` +
-        `Hint: ${matchedProvider.name} requires IMAP access to be manually enabled. ` +
-        `Go to: ${matchedProvider.settingsPath}`
-      );
-    }
-    // Generic hint when error looks IMAP-related but provider is unknown
+  if (matchedProvider) {
     return (
       `${originalMessage}\n\n` +
-      `Hint: Some providers (e.g. GMX, WEB.DE, Zoho) require IMAP access to be manually enabled ` +
-      `in the account settings (usually under Settings → Email → POP3 & IMAP).`
+      `Hint: ${matchedProvider.name} requires IMAP access to be manually enabled. ` +
+      `Go to: ${matchedProvider.settingsPath}`
     );
   }
 
-  return originalMessage;
+  // Generic hint when error looks IMAP-related but provider is unknown
+  return (
+    `${originalMessage}\n\n` +
+    `Hint: Some providers (e.g. GMX, WEB.DE, Zoho) require IMAP access to be manually enabled ` +
+    `in the account settings (usually under Settings → Email → POP3 & IMAP).`
+  );
 }
 
 interface ConnectionState {

--- a/tests/imap-service.test.ts
+++ b/tests/imap-service.test.ts
@@ -117,6 +117,14 @@ describe('ImapService', () => {
       expect(mockInstance.onMock).toHaveBeenCalledWith('error', expect.any(Function));
       expect(mockInstance.onMock).toHaveBeenCalledWith('close', expect.any(Function));
     });
+
+    it('should not append IMAP enable hint for unrelated Gmail auth failures', async () => {
+      mockAccount.host = 'imap.gmail.com';
+      mockInstance.connectMock.mockRejectedValue(new Error('Authentication failed'));
+
+      await expect(imapService.connect(mockAccount)).rejects.toThrow('Authentication failed');
+      await expect(imapService.connect(mockAccount)).rejects.not.toThrow(/Enable IMAP|Forwarding and POP\/IMAP/);
+    });
   });
 
   describe('disconnect', () => {
@@ -169,6 +177,18 @@ describe('ImapService', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Connection refused');
+    });
+
+    it('should append provider-specific hint for explicit IMAP-disabled errors', async () => {
+      mockAccount.host = 'imap.gmx.net';
+      mockInstance.connectMock.mockRejectedValue(new Error('[ALERT] IMAP access disabled'));
+
+      const result = await imapService.testConnection(mockAccount);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('[ALERT] IMAP access disabled');
+      expect(result.error).toContain('Hint: GMX requires IMAP access to be manually enabled.');
+      expect(result.error).toContain('Settings → Email → POP3 & IMAP → Enable IMAP access');
     });
   });
 


### PR DESCRIPTION
## Summary

- only append provider-specific IMAP hints when the server error actually matches an IMAP-disabled pattern
- preserve the original error for unrelated Gmail and other provider failures such as bad credentials
- add regression tests for both `connect()` and `testConnection()` paths

## Why

The current enrichment logic adds provider remediation hints whenever the host matches a known provider, even if the underlying failure is unrelated to IMAP being disabled. That can send users to the wrong fix path for auth or transient connection failures.

## Test plan

- [x] `npm test -- tests/imap-service.test.ts`
- [x] `npm test`
