### PR TITLE
feat(mcp): add imap_save_draft tool

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -661,23 +661,31 @@ export class ImapService {
   }
 
   async appendToSentFolder(accountId: string, rawMessage: Buffer | string): Promise<boolean> {
-    const client = await this.ensureConnected(accountId);
-
-    // Auto-detect sent folder name
-    const folders = await this.listFolders(accountId);
     const sentFolderNames = ['Sent Messages', 'Sent', 'INBOX.Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail'];
-    const sentFolder = folders.find(f => sentFolderNames.includes(f.name));
-
-    if (!sentFolder) {
+    const folder = await this.findFolderByNames(accountId, sentFolderNames);
+    if (!folder) {
       console.warn(`[IMAP] No sent folder found for account ${accountId}. Tried: ${sentFolderNames.join(', ')}`);
       return false;
     }
+    return this.appendMessage(accountId, folder, rawMessage, ['\\Seen']);
+  }
 
+  async findFolderByNames(accountId: string, candidates: string[]): Promise<string | undefined> {
+    const folders = await this.listFolders(accountId);
+    return folders.find(f => candidates.includes(f.name))?.name;
+  }
+
+  async findDraftsFolder(accountId: string): Promise<string | undefined> {
+    return this.findFolderByNames(accountId, ['Drafts', 'Draft', 'INBOX.Drafts', 'INBOX.Draft', '[Gmail]/Drafts']);
+  }
+
+  async appendMessage(accountId: string, folder: string, rawMessage: Buffer | string, flags?: string[]): Promise<boolean> {
+    const client = await this.ensureConnected(accountId);
     try {
-      await client.append(sentFolder.name, rawMessage, ['\\Seen']);
+      await client.append(folder, rawMessage, flags ?? []);
       return true;
     } catch (err) {
-      console.error(`[IMAP] Failed to append to ${sentFolder.name}:`, err instanceof Error ? err.message : err);
+      console.error(`[IMAP] Failed to append to ${folder}:`, err instanceof Error ? err.message : err);
       return false;
     }
   }

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -90,36 +90,44 @@ export class SmtpService {
     };
   }
 
+  private toMailOptions(account: ImapAccount, email: EmailComposer): nodemailer.SendMailOptions {
+    return {
+      from: email.from || account.email || account.user,
+      to: email.to,
+      cc: email.cc,
+      bcc: email.bcc,
+      subject: email.subject,
+      text: email.text,
+      html: email.html,
+      attachments: email.attachments?.map(att => ({
+        filename: att.filename,
+        content: att.content,
+        path: att.path,
+        contentType: att.contentType,
+        contentDisposition: att.contentDisposition,
+        cid: att.cid,
+      })),
+      replyTo: email.replyTo,
+      inReplyTo: email.inReplyTo,
+      references: Array.isArray(email.references) ? email.references.join(' ') : email.references,
+    };
+  }
+
+  // Build the raw RFC 822 message without sending. Used for drafts and Sent-folder copies.
+  async composeRaw(account: ImapAccount, email: EmailComposer): Promise<Buffer> {
+    const compiled = new MailComposer(this.toMailOptions(account, email));
+    return compiled.compile().build();
+  }
+
   async sendEmail(accountId: string, account: ImapAccount, email: EmailComposer): Promise<{ messageId: string; rawMessage?: Buffer }> {
     try {
       const transporter = await this.createTransporter(account);
-
-      const mailOptions: nodemailer.SendMailOptions = {
-        from: email.from || account.email || account.user,
-        to: email.to,
-        cc: email.cc,
-        bcc: email.bcc,
-        subject: email.subject,
-        text: email.text,
-        html: email.html,
-        attachments: email.attachments?.map(att => ({
-          filename: att.filename,
-          content: att.content,
-          path: att.path,
-          contentType: att.contentType,
-          contentDisposition: att.contentDisposition,
-          cid: att.cid,
-        })),
-        replyTo: email.replyTo,
-        inReplyTo: email.inReplyTo,
-        references: Array.isArray(email.references) ? email.references.join(' ') : email.references,
-      };
+      const mailOptions = this.toMailOptions(account, email);
 
       // Build raw message for IMAP Sent folder append
       let rawMessage: Buffer | undefined;
       try {
-        const compiled = new MailComposer(mailOptions);
-        rawMessage = await compiled.compile().build();
+        rawMessage = await this.composeRaw(account, email);
       } catch {
         // Non-critical: sent folder copy will be skipped
       }

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -504,6 +504,77 @@ export function emailTools(
     };
   });
 
+  // Save draft tool — composes a message and appends it to the Drafts folder with the \Draft flag
+  server.registerTool('imap_save_draft', {
+    description: 'Save an email as a draft in the Drafts folder (no send). Takes the same fields as imap_send_email.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID to save the draft under'),
+      to: z.union([z.string(), z.array(z.string())]).optional().describe('Recipient email address(es)'),
+      subject: z.string().optional().describe('Email subject'),
+      text: z.string().optional().describe('Plain text content'),
+      html: z.string().optional().describe('HTML content'),
+      cc: z.union([z.string(), z.array(z.string())]).optional().describe('CC recipients'),
+      bcc: z.union([z.string(), z.array(z.string())]).optional().describe('BCC recipients'),
+      replyTo: z.string().optional().describe('Reply-to address'),
+      inReplyTo: z.string().optional().describe('Message-Id being replied to'),
+      references: z.union([z.string(), z.array(z.string())]).optional().describe('References header value(s)'),
+      attachments: z.array(z.object({
+        filename: z.string().describe('Attachment filename'),
+        content: z.string().optional().describe('Base64 encoded content'),
+        path: z.string().optional().describe('File path to attach'),
+        contentType: z.string().optional().describe('MIME type'),
+      })).optional().describe('Email attachments'),
+      folder: z.string().optional().describe('Override the Drafts folder name (defaults to auto-detected Drafts folder)'),
+    }
+  }, async ({ accountId, to, subject, text, html, cc, bcc, replyTo, inReplyTo, references, attachments, folder }) => {
+    const account = await accountManager.getAccount(accountId);
+    if (!account) {
+      throw new Error(`Account ${accountId} not found`);
+    }
+
+    const emailComposer = {
+      from: account.email || account.user,
+      to: to ?? '',
+      subject: subject ?? '',
+      text,
+      html,
+      cc,
+      bcc,
+      replyTo,
+      inReplyTo,
+      references,
+      attachments: attachments?.map(att => ({
+        filename: att.filename,
+        content: att.content ? Buffer.from(att.content, 'base64') : undefined,
+        path: att.path,
+        contentType: att.contentType,
+      })),
+    };
+
+    const rawMessage = await smtpService.composeRaw(account, emailComposer);
+
+    const draftsFolder = folder ?? await imapService.findDraftsFolder(accountId);
+    if (!draftsFolder) {
+      throw new Error('No Drafts folder found. Tried: Drafts, Draft, INBOX.Drafts, INBOX.Draft, [Gmail]/Drafts. Pass `folder` to override.');
+    }
+
+    const appended = await imapService.appendMessage(accountId, draftsFolder, rawMessage, ['\\Draft', '\\Seen']);
+    if (!appended) {
+      throw new Error(`Failed to append draft to folder "${draftsFolder}"`);
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          folder: draftsFolder,
+          message: `Draft saved to "${draftsFolder}"`,
+        }, null, 2)
+      }]
+    };
+  });
+
   // Reply to email tool
   server.registerTool('imap_reply_to_email', {
     description: 'Reply to an existing email',


### PR DESCRIPTION
Expose a tool that composes an email from the same fields as imap_send_email and appends it to the Drafts folder with the IMAP \Draft flag, instead of sending. All content fields are optional so partial drafts (empty subject, no body) can be saved.

Folder is auto-detected from the common names (Drafts, Draft, INBOX.Drafts, INBOX.Draft, [Gmail]/Drafts) with an explicit `folder` override if the server uses a different name.

Extract two reusable helpers in the process:
- SmtpService.composeRaw (via toMailOptions) builds raw RFC 822 without sending; sendEmail now reuses it for the Sent-folder copy.
- ImapService.appendMessage is a generic append primitive; appendToSentFolder becomes a thin wrapper over it plus the new findFolderByNames / findDraftsFolder lookups.