### PR TITLE
fix(smtp): normalize TLS mode and add imap_update_account tool

### DIFF
--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -11,11 +11,13 @@ export class SmtpService {
     }
 
     const smtpConfig = account.smtp || this.getDefaultSmtpConfig(account);
-    
+    const { secure, requireTLS } = this.resolveTlsMode(smtpConfig.port, smtpConfig.secure);
+
     const transporterOptions = {
       host: smtpConfig.host,
       port: smtpConfig.port,
-      secure: smtpConfig.secure,
+      secure,
+      requireTLS,
       auth: {
         user: smtpConfig.user || account.user,
         pass: smtpConfig.password || account.password,
@@ -30,6 +32,14 @@ export class SmtpService {
     
     this.transporters.set(account.id, transporter);
     return transporter;
+  }
+
+  // Port 465 is implicit TLS (SMTPS); 587/25 are submission ports that upgrade via STARTTLS.
+  // A stored `secure: true` on port 587 is almost always a UI mistake — normalize it.
+  private resolveTlsMode(port: number, secure: boolean): { secure: boolean; requireTLS: boolean } {
+    if (port === 465) return { secure: true, requireTLS: false };
+    if (port === 587 || port === 25) return { secure: false, requireTLS: true };
+    return { secure, requireTLS: !secure };
   }
 
   private getDefaultSmtpConfig(account: ImapAccount): SmtpConfig {
@@ -82,11 +92,15 @@ export class SmtpService {
       return providerConfig;
     }
 
-    // Default: assume SMTP server is on same host with standard ports
+    // Default: submission port 587 with STARTTLS (RFC 8314 recommended).
+    // Guess SMTP host: rewrite imap.* to smtp.* if present, otherwise reuse the IMAP host.
+    const smtpHost = account.host.startsWith('imap.') || account.host.startsWith('imap-')
+      ? account.host.replace(/^imap[.-]/, (m) => m === 'imap.' ? 'smtp.' : 'smtp-')
+      : account.host;
     return {
-      host: account.host.replace('imap.', 'smtp.').replace('imap-', 'smtp-'),
-      port: account.tls ? 465 : 587,
-      secure: account.port === 993,
+      host: smtpHost,
+      port: 587,
+      secure: false,
     };
   }
 

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -1,12 +1,14 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { AccountManager } from '../services/account-manager.js';
 import { ImapService } from '../services/imap-service.js';
+import { SmtpService } from '../services/smtp-service.js';
 import { z } from 'zod';
 
 export function accountTools(
   server: McpServer,
   accountManager: AccountManager,
-  imapService: ImapService
+  imapService: ImapService,
+  smtpService: SmtpService
 ): void {
   // Add account tool
   server.registerTool('imap_add_account', {
@@ -18,8 +20,20 @@ export function accountTools(
       user: z.string().describe('Username for authentication'),
       password: z.string().describe('Password for authentication'),
       tls: z.boolean().default(true).describe('Use TLS/SSL (default: true)'),
+      email: z.string().optional().describe('Email address (From: header). Defaults to user if omitted'),
+      smtpHost: z.string().optional().describe('SMTP server hostname. Defaults to IMAP host with imap.→smtp. rewrite'),
+      smtpPort: z.coerce.number().optional().describe('SMTP server port (465 for SMTPS, 587 for STARTTLS). Defaults to 587'),
+      smtpSecure: z.boolean().optional().describe('Use implicit TLS (SMTPS). Ignored for port 587/25 which always use STARTTLS, and for port 465 which always uses implicit TLS'),
     }
-  }, async ({ name, host, port, user, password, tls }) => {
+  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure }) => {
+    const smtp = (smtpHost || smtpPort !== undefined || smtpSecure !== undefined)
+      ? {
+          host: smtpHost || host,
+          port: smtpPort ?? 587,
+          secure: smtpSecure ?? false,
+        }
+      : undefined;
+
     const account = await accountManager.addAccount({
       name,
       host,
@@ -27,8 +41,10 @@ export function accountTools(
       user,
       password,
       tls,
+      ...(email ? { email } : {}),
+      ...(smtp ? { smtp } : {}),
     });
-    
+
     return {
       content: [{
         type: 'text',
@@ -36,6 +52,73 @@ export function accountTools(
           success: true,
           accountId: account.id,
           message: `Account "${name}" added successfully`,
+        }, null, 2)
+      }]
+    };
+  });
+
+  // Update account tool — lets callers fix SMTP config (and other fields) on existing accounts
+  server.registerTool('imap_update_account', {
+    description: 'Update an existing IMAP account. Useful for fixing SMTP settings without removing and re-adding the account.',
+    inputSchema: {
+      accountId: z.string().describe('ID of the account to update'),
+      name: z.string().optional().describe('New friendly name'),
+      host: z.string().optional().describe('IMAP host'),
+      port: z.coerce.number().optional().describe('IMAP port'),
+      user: z.string().optional().describe('IMAP username'),
+      password: z.string().optional().describe('New password'),
+      tls: z.boolean().optional().describe('Use TLS for IMAP'),
+      email: z.string().optional().describe('Email address (From: header)'),
+      smtpHost: z.string().optional().describe('SMTP hostname'),
+      smtpPort: z.coerce.number().optional().describe('SMTP port (465 for SMTPS, 587 for STARTTLS)'),
+      smtpSecure: z.boolean().optional().describe('Use implicit TLS (SMTPS). Port 587/25 always use STARTTLS regardless'),
+      smtpUser: z.string().optional().describe('SMTP username (if different from IMAP user)'),
+      smtpPassword: z.string().optional().describe('SMTP password (if different from IMAP password)'),
+      saveToSent: z.boolean().optional().describe('Save sent emails to the Sent folder'),
+    }
+  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent }) => {
+    const existing = accountManager.getAccount(accountId);
+    if (!existing) {
+      throw new Error(`Account ${accountId} not found`);
+    }
+
+    const updates: any = {};
+    if (name !== undefined) updates.name = name;
+    if (host !== undefined) updates.host = host;
+    if (port !== undefined) updates.port = port;
+    if (user !== undefined) updates.user = user;
+    if (password !== undefined) updates.password = password;
+    if (tls !== undefined) updates.tls = tls;
+    if (email !== undefined) updates.email = email;
+    if (saveToSent !== undefined) updates.saveToSent = saveToSent;
+
+    const smtpTouched = [smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword].some(v => v !== undefined);
+    if (smtpTouched) {
+      const current = existing.smtp;
+      updates.smtp = {
+        host: smtpHost ?? current?.host ?? existing.host,
+        port: smtpPort ?? current?.port ?? 587,
+        secure: smtpSecure ?? current?.secure ?? false,
+        ...(smtpUser !== undefined ? { user: smtpUser } : current?.user ? { user: current.user } : {}),
+        ...(smtpPassword !== undefined ? { password: smtpPassword } : {}),
+      };
+    }
+
+    // Invalidate any cached SMTP transporter so the next send picks up new config
+    if (smtpTouched) {
+      smtpService.disconnect(accountId);
+    }
+
+    const updated = await accountManager.updateAccount(accountId, updates);
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          success: true,
+          accountId: updated.id,
+          message: `Account "${updated.name}" updated`,
+          smtp: updated.smtp ? { host: updated.smtp.host, port: updated.smtp.port, secure: updated.smtp.secure } : undefined,
         }, null, 2)
       }]
     };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,7 +16,7 @@ export function registerTools(
   spamService: SpamService
 ): void {
   // Register account management tools
-  accountTools(server, accountManager, imapService);
+  accountTools(server, accountManager, imapService, smtpService);
 
   // Register email operation tools
   emailTools(server, imapService, accountManager, smtpService);


### PR DESCRIPTION
## Summary

  - **SMTP TLS fix**: The web UI could produce broken configs (e.g. `secure: true` on port 587 which speaks STARTTLS, not implicit TLS), causing SSL handshake failures. Adds `resolveTlsMode()` normalizer: port 465 → implicit TLS, port 587/25 → STARTTLS, others honor the stored flag. Also improves SMTP fallback defaults.
  - **`imap_update_account`**: New MCP tool to update any field on an existing account (IMAP, SMTP, email, saveToSent) without removing and re-adding it. Invalidates the cached nodemailer transporter when SMTP fields change.
  - **SMTP fields on `imap_add_account`**: SMTP config was previously only reachable via the web UI. Now exposed directly as optional params on the add tool.

  ## Test plan

  - [ ] Add an account with port 587 + `secure: true` via web UI — verify send no longer fails with SSL version error
  - [ ] Call `imap_update_account` to change SMTP host/port on an existing account — verify next send uses new config
  - [ ] Call `imap_add_account` with explicit `smtpHost`/`smtpPort` params — verify account is saved correctly
  
    🤖 Generated with [Claude Code](https://claude.com/claude-code)