### PR TITLE
feat: imap_create_folder, imap_find_thread_messages, auto-create on move

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,16 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - folder: Source folder name (default: INBOX)
   - uid: Email UID
   - targetFolder: Destination folder name
+  - createDestinationIfMissing: Create the destination folder if it does not exist (default: false)
+  ```
+
+- **imap_find_thread_messages**: Find inbox messages that belong to the same conversation threads as messages already sorted into another folder. Uses RFC 3501 HEADER search on In-Reply-To and References — works on any IMAP server.
+  ```
+  Parameters:
+  - accountId: Account ID
+  - sourceFolder: Folder containing the already-sorted thread messages
+  - searchFolder: Folder to search for related messages (default: INBOX)
+  - searchReferences: Also match the References header for multi-level threads (default: true)
   ```
 
 - **imap_download_attachment**: Download an email attachment (returns images inline, extracts text from PDFs, or saves to downloads directory)
@@ -320,6 +330,13 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   Parameters:
   - accountId: Account ID
   - folder: Folder name
+  ```
+
+- **imap_create_folder**: Create a new IMAP folder/mailbox. Most servers also create any missing parent folders. Returns success even if the folder already exists.
+  ```
+  Parameters:
+  - accountId: Account ID
+  - folder: Full folder path to create (e.g. "Archives/2026/2026-05" or "INBOX.Archive")
   ```
 
 - **imap_get_unread_count**: Count unread emails

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imap-mcp-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A powerful Model Context Protocol (MCP) server for IMAP email integration with Claude",
   "main": "dist/index.js",
   "bin": {

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -636,8 +636,23 @@ export class ImapService {
     return { deleted, failed, errors };
   }
 
-  async moveEmail(accountId: string, folderName: string, uid: number, targetFolder: string): Promise<{ path: string; destination: string; uidMap?: Map<number, number> }> {
+  async moveEmail(
+    accountId: string,
+    folderName: string,
+    uid: number,
+    targetFolder: string,
+    options?: { createDestinationIfMissing?: boolean },
+  ): Promise<{ path: string; destination: string; destinationCreated?: boolean; uidMap?: Map<number, number> }> {
     const client = await this.ensureConnected(accountId);
+
+    let destinationCreated = false;
+    if (options?.createDestinationIfMissing) {
+      const exists = await this.folderExists(accountId, targetFolder);
+      if (!exists) {
+        await this.createFolder(accountId, targetFolder);
+        destinationCreated = true;
+      }
+    }
 
     let lock;
     try {
@@ -651,6 +666,7 @@ export class ImapService {
       return {
         path: result.path,
         destination: result.destination,
+        destinationCreated: destinationCreated || undefined,
         uidMap: result.uidMap,
       };
     } finally {
@@ -658,6 +674,98 @@ export class ImapService {
         lock.release();
       }
     }
+  }
+
+  async folderExists(accountId: string, folderPath: string): Promise<boolean> {
+    const client = await this.ensureConnected(accountId);
+    const list = await client.list();
+    return list.some(f => f.path === folderPath);
+  }
+
+  async createFolder(
+    accountId: string,
+    folderPath: string,
+  ): Promise<{ path: string; created: boolean; alreadyExisted: boolean }> {
+    const client = await this.ensureConnected(accountId);
+    try {
+      const result = await client.mailboxCreate(folderPath);
+      const path = (result && typeof result === 'object' && 'path' in result) ? (result as any).path : folderPath;
+      const created = (result && typeof result === 'object' && 'created' in result) ? Boolean((result as any).created) : true;
+      return {
+        path,
+        created,
+        alreadyExisted: !created,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // ImapFlow throws on already-existing mailboxes; treat that as a non-error.
+      if (/already exists|exists/i.test(message)) {
+        return { path: folderPath, created: false, alreadyExisted: true };
+      }
+      throw new Error(`Failed to create folder "${folderPath}": ${message}`);
+    }
+  }
+
+  async findThreadMessages(
+    accountId: string,
+    sourceFolder: string,
+    searchFolder: string,
+    options?: { searchReferences?: boolean },
+  ): Promise<{ messageIds: string[]; uids: number[] }> {
+    const client = await this.ensureConnected(accountId);
+    const includeReferences = options?.searchReferences !== false;
+
+    // 1) Collect Message-IDs from sourceFolder
+    const messageIds: string[] = [];
+    let lock = await client.getMailboxLock(sourceFolder);
+    try {
+      const allUids = await client.search({ all: true }, { uid: true });
+      if (allUids.length > 0) {
+        for await (const msg of client.fetch(allUids, { uid: true, envelope: true }, { uid: true })) {
+          if (msg.envelope?.messageId) {
+            messageIds.push(msg.envelope.messageId);
+          }
+        }
+      }
+    } finally {
+      lock.release();
+    }
+
+    if (messageIds.length === 0) {
+      return { messageIds: [], uids: [] };
+    }
+
+    // 2) For each Message-ID, search In-Reply-To (and optionally References) in searchFolder
+    const foundUids = new Set<number>();
+    lock = await client.getMailboxLock(searchFolder);
+    try {
+      for (const msgId of messageIds) {
+        try {
+          const inReplyMatches = await client.search(
+            { header: { 'in-reply-to': msgId } as any },
+            { uid: true },
+          );
+          for (const uid of inReplyMatches) foundUids.add(uid);
+
+          if (includeReferences) {
+            const refMatches = await client.search(
+              { header: { 'references': msgId } as any },
+              { uid: true },
+            );
+            for (const uid of refMatches) foundUids.add(uid);
+          }
+        } catch {
+          // Skip per-message errors so one bad search doesn't kill the whole sweep
+        }
+      }
+    } finally {
+      lock.release();
+    }
+
+    return {
+      messageIds,
+      uids: Array.from(foundUids).sort((a, b) => a - b),
+    };
   }
 
   async appendToSentFolder(accountId: string, rawMessage: Buffer | string): Promise<boolean> {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -265,16 +265,19 @@ export function emailTools(
 
   // Move email to another folder
   server.registerTool('imap_move_email', {
-    description: 'Move an email from one folder to another (e.g., INBOX to Taxes, or INBOX to Archive)',
+    description: 'Move an email from one folder to another (e.g., INBOX to Taxes, or INBOX to Archive). Optionally creates the destination folder if it does not exist.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Source folder name'),
       uid: z.coerce.number().describe('Email UID'),
       targetFolder: z.string().describe('Destination folder name'),
+      createDestinationIfMissing: z.boolean().optional().describe('If true, create the destination folder before moving when it does not exist (default: false)'),
     }
-  }, async ({ accountId, folder, uid, targetFolder }) => {
+  }, async ({ accountId, folder, uid, targetFolder, createDestinationIfMissing }) => {
     try {
-      const result = await imapService.moveEmail(accountId, folder, uid, targetFolder);
+      const result = await imapService.moveEmail(accountId, folder, uid, targetFolder, {
+        createDestinationIfMissing,
+      });
 
       const uidMapObj: Record<string, number> = {};
       if (result.uidMap) {
@@ -290,6 +293,7 @@ export function emailTools(
             success: true,
             message: `Email ${uid} moved from ${folder} to ${targetFolder}`,
             destination: result.destination,
+            destinationCreated: result.destinationCreated,
             uidMap: Object.keys(uidMapObj).length > 0 ? uidMapObj : undefined,
           }, null, 2)
         }]
@@ -700,5 +704,49 @@ export function emailTools(
         }, null, 2)
       }]
     };
+  });
+
+  // Find thread messages tool
+  server.registerTool('imap_find_thread_messages', {
+    description:
+      'Find messages in `searchFolder` that belong to the same conversation threads as messages already in `sourceFolder`. ' +
+      'Useful for catching replies that arrived after a thread was sorted. Works on any IMAP server (uses RFC 3501 HEADER search on In-Reply-To and References).',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      sourceFolder: z.string().describe('Folder containing the already-sorted thread messages (e.g. "Review.Articles")'),
+      searchFolder: z.string().default('INBOX').describe('Folder to search for related thread messages (default: INBOX)'),
+      searchReferences: z.boolean().optional().describe('Also search the References header for multi-level threads (default: true)'),
+    }
+  }, async ({ accountId, sourceFolder, searchFolder, searchReferences }) => {
+    try {
+      const result = await imapService.findThreadMessages(accountId, sourceFolder, searchFolder, {
+        searchReferences,
+      });
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            sourceFolder,
+            searchFolder,
+            sourceMessageIdCount: result.messageIds.length,
+            threadMessageCount: result.uids.length,
+            uids: result.uids,
+          }, null, 2)
+        }]
+      };
+    } catch (err) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            sourceFolder,
+            searchFolder,
+            error: err instanceof Error ? err.message : 'Unknown error',
+          }, null, 2)
+        }]
+      };
+    }
   });
 }

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -61,6 +61,47 @@ export function folderTools(
     };
   });
 
+  // Create folder tool
+  server.registerTool('imap_create_folder', {
+    description:
+      'Create a new IMAP folder/mailbox. Most servers also create any missing parent folders ' +
+      '(e.g. creating "Archives/2026/2026-05" auto-creates "Archives" and "Archives/2026"). ' +
+      'Returns success even if the folder already exists.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      folder: z.string().describe('Full folder path to create (e.g. "Archives/2026/2026-05" or "INBOX.Archive")'),
+    }
+  }, async ({ accountId, folder }) => {
+    try {
+      const result = await imapService.createFolder(accountId, folder);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            folder: result.path,
+            created: result.created,
+            alreadyExisted: result.alreadyExisted,
+            message: result.alreadyExisted
+              ? `Folder "${result.path}" already existed`
+              : `Folder "${result.path}" created`,
+          }, null, 2)
+        }]
+      };
+    } catch (err) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            folder,
+            error: err instanceof Error ? err.message : 'Unknown error',
+          }, null, 2)
+        }]
+      };
+    }
+  });
+
   // Get unread count tool
   server.registerTool('imap_get_unread_count', {
     description: 'Get the count of unread emails in specified folders',

--- a/tests/email-tools-move.test.ts
+++ b/tests/email-tools-move.test.ts
@@ -106,6 +106,30 @@ describe('imap_move_email Tool Handler', () => {
     expect(parsed.error).toBe('Unknown error');
   });
 
+  it('should pass createDestinationIfMissing through to service and surface destinationCreated', async () => {
+    mockImapService.moveEmail.mockResolvedValueOnce({
+      path: 'INBOX',
+      destination: 'Archive/2026',
+      destinationCreated: true,
+    });
+
+    const result = await moveEmailHandler({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: 7,
+      targetFolder: 'Archive/2026',
+      createDestinationIfMissing: true,
+    });
+
+    expect(mockImapService.moveEmail).toHaveBeenCalledWith(
+      'acc1', 'INBOX', 7, 'Archive/2026',
+      { createDestinationIfMissing: true },
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.destinationCreated).toBe(true);
+  });
+
   it('should serialize multiple uidMap entries correctly', async () => {
     mockImapService.moveEmail.mockResolvedValueOnce({
       path: 'INBOX',

--- a/tests/email-tools-thread.test.ts
+++ b/tests/email-tools-thread.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emailTools } from '../src/tools/email-tools.js';
+
+let findThreadMessagesHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_find_thread_messages') {
+      findThreadMessagesHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  findThreadMessages: vi.fn(),
+};
+
+describe('imap_find_thread_messages Tool Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emailTools(mockServer as any, mockImapService as any, {} as any, {} as any);
+  });
+
+  it('should be registered', () => {
+    expect(findThreadMessagesHandler).toBeDefined();
+  });
+
+  it('should return thread UIDs and counts on success', async () => {
+    mockImapService.findThreadMessages.mockResolvedValueOnce({
+      messageIds: ['<a@x>', '<b@x>'],
+      uids: [100, 101, 102],
+    });
+
+    const result = await findThreadMessagesHandler({
+      accountId: 'acc1',
+      sourceFolder: 'Review',
+      searchFolder: 'INBOX',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.sourceMessageIdCount).toBe(2);
+    expect(parsed.threadMessageCount).toBe(3);
+    expect(parsed.uids).toEqual([100, 101, 102]);
+  });
+
+  it('should pass searchReferences flag through to service', async () => {
+    mockImapService.findThreadMessages.mockResolvedValueOnce({
+      messageIds: [],
+      uids: [],
+    });
+
+    await findThreadMessagesHandler({
+      accountId: 'acc1',
+      sourceFolder: 'Review',
+      searchFolder: 'INBOX',
+      searchReferences: false,
+    });
+
+    expect(mockImapService.findThreadMessages).toHaveBeenCalledWith(
+      'acc1',
+      'Review',
+      'INBOX',
+      { searchReferences: false },
+    );
+  });
+
+  it('should return success:false when service throws', async () => {
+    mockImapService.findThreadMessages.mockRejectedValueOnce(new Error('folder missing'));
+
+    const result = await findThreadMessagesHandler({
+      accountId: 'acc1',
+      sourceFolder: 'Nope',
+      searchFolder: 'INBOX',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('folder missing');
+  });
+});

--- a/tests/folder-tools-create.test.ts
+++ b/tests/folder-tools-create.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { folderTools } from '../src/tools/folder-tools.js';
+
+let createFolderHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_create_folder') {
+      createFolderHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  createFolder: vi.fn(),
+};
+
+describe('imap_create_folder Tool Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    folderTools(mockServer as any, mockImapService as any, {} as any);
+  });
+
+  it('should be registered', () => {
+    expect(createFolderHandler).toBeDefined();
+  });
+
+  it('should report success when a new folder is created', async () => {
+    mockImapService.createFolder.mockResolvedValueOnce({
+      path: 'Archives/2026',
+      created: true,
+      alreadyExisted: false,
+    });
+
+    const result = await createFolderHandler({ accountId: 'acc1', folder: 'Archives/2026' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.created).toBe(true);
+    expect(parsed.alreadyExisted).toBe(false);
+    expect(parsed.message).toContain('created');
+  });
+
+  it('should report success when the folder already existed', async () => {
+    mockImapService.createFolder.mockResolvedValueOnce({
+      path: 'INBOX',
+      created: false,
+      alreadyExisted: true,
+    });
+
+    const result = await createFolderHandler({ accountId: 'acc1', folder: 'INBOX' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.alreadyExisted).toBe(true);
+    expect(parsed.message).toContain('already existed');
+  });
+
+  it('should report failure when service throws', async () => {
+    mockImapService.createFolder.mockRejectedValueOnce(new Error('Permission denied'));
+
+    const result = await createFolderHandler({ accountId: 'acc1', folder: 'Forbidden' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toBe('Permission denied');
+  });
+});

--- a/tests/imap-service.test.ts
+++ b/tests/imap-service.test.ts
@@ -17,6 +17,7 @@ class MockImapFlow {
   public messageFlagsRemoveMock = vi.fn().mockResolvedValue(undefined);
   public messageDeleteMock = vi.fn().mockResolvedValue(undefined);
   public messageMoveMock = vi.fn().mockResolvedValue({ path: 'INBOX', destination: 'Archive', uidMap: new Map([[123, 456]]) });
+  public mailboxCreateMock = vi.fn().mockResolvedValue({ path: 'NewFolder', created: true });
   public statusMock = vi.fn().mockResolvedValue({ messages: 10 });
   public usable = true;
   public onMock = vi.fn();
@@ -33,6 +34,7 @@ class MockImapFlow {
   messageFlagsRemove(uid: any, flags: any, opts: any) { return this.messageFlagsRemoveMock(uid, flags, opts); }
   messageDelete(uid: any, opts: any) { return this.messageDeleteMock(uid, opts); }
   messageMove(uid: any, target: any, opts: any) { return this.messageMoveMock(uid, target, opts); }
+  mailboxCreate(path: any) { return this.mailboxCreateMock(path); }
   status(name: string, opts: any) { return this.statusMock(name, opts); }
   on(event: string, handler: any) { return this.onMock(event, handler); }
 }
@@ -59,6 +61,7 @@ vi.mock('imapflow', () => {
         this.messageFlagsRemove = mockInstance.messageFlagsRemove.bind(mockInstance);
         this.messageDelete = mockInstance.messageDelete.bind(mockInstance);
         this.messageMove = mockInstance.messageMove.bind(mockInstance);
+        this.mailboxCreate = mockInstance.mailboxCreate.bind(mockInstance);
         this.status = mockInstance.status.bind(mockInstance);
         this.on = mockInstance.on.bind(mockInstance);
       }
@@ -470,11 +473,154 @@ describe('ImapService', () => {
       await imapService.connect(mockAccount);
       const result = await imapService.moveEmail(mockAccount.id, 'INBOX', 123, 'Taxes');
 
-      expect(result).toEqual({
-        path: 'INBOX',
-        destination: 'Taxes',
-        uidMap: undefined,
+      expect(result.path).toBe('INBOX');
+      expect(result.destination).toBe('Taxes');
+      expect(result.uidMap).toBeUndefined();
+    });
+
+    it('should auto-create destination when missing if requested', async () => {
+      mockInstance.listMock.mockResolvedValue([{ path: 'INBOX', delimiter: '/', flags: [] }]);
+      mockInstance.mailboxCreateMock.mockResolvedValueOnce({ path: 'Archive/2026', created: true });
+      await imapService.connect(mockAccount);
+
+      const result = await imapService.moveEmail(
+        mockAccount.id, 'INBOX', 123, 'Archive/2026',
+        { createDestinationIfMissing: true },
+      );
+
+      expect(mockInstance.mailboxCreateMock).toHaveBeenCalledWith('Archive/2026');
+      expect(result.destinationCreated).toBe(true);
+      expect(mockInstance.messageMoveMock).toHaveBeenCalled();
+    });
+
+    it('should not create destination when it already exists', async () => {
+      mockInstance.listMock.mockResolvedValue([
+        { path: 'INBOX', delimiter: '/', flags: [] },
+        { path: 'Archive', delimiter: '/', flags: [] },
+      ]);
+      await imapService.connect(mockAccount);
+
+      const result = await imapService.moveEmail(
+        mockAccount.id, 'INBOX', 123, 'Archive',
+        { createDestinationIfMissing: true },
+      );
+
+      expect(mockInstance.mailboxCreateMock).not.toHaveBeenCalled();
+      expect(result.destinationCreated).toBeUndefined();
+    });
+  });
+
+  describe('createFolder', () => {
+    it('should create a new folder and return success', async () => {
+      mockInstance.mailboxCreateMock.mockResolvedValueOnce({ path: 'Archive', created: true });
+      await imapService.connect(mockAccount);
+
+      const result = await imapService.createFolder(mockAccount.id, 'Archive');
+
+      expect(mockInstance.mailboxCreateMock).toHaveBeenCalledWith('Archive');
+      expect(result).toEqual({ path: 'Archive', created: true, alreadyExisted: false });
+    });
+
+    it('should mark already-existing folders as alreadyExisted', async () => {
+      mockInstance.mailboxCreateMock.mockResolvedValueOnce({ path: 'INBOX', created: false });
+      await imapService.connect(mockAccount);
+
+      const result = await imapService.createFolder(mockAccount.id, 'INBOX');
+
+      expect(result).toEqual({ path: 'INBOX', created: false, alreadyExisted: true });
+    });
+
+    it('should treat "already exists" errors as alreadyExisted, not failures', async () => {
+      mockInstance.mailboxCreateMock.mockRejectedValueOnce(new Error('Mailbox already exists'));
+      await imapService.connect(mockAccount);
+
+      const result = await imapService.createFolder(mockAccount.id, 'INBOX');
+
+      expect(result).toEqual({ path: 'INBOX', created: false, alreadyExisted: true });
+    });
+
+    it('should rethrow with context on real failures', async () => {
+      mockInstance.mailboxCreateMock.mockRejectedValueOnce(new Error('Permission denied'));
+      await imapService.connect(mockAccount);
+
+      await expect(
+        imapService.createFolder(mockAccount.id, 'Forbidden'),
+      ).rejects.toThrow('Failed to create folder "Forbidden": Permission denied');
+    });
+  });
+
+  describe('findThreadMessages', () => {
+    it('should collect Message-IDs from source and search for replies in target', async () => {
+      mockInstance.searchMock
+        .mockResolvedValueOnce([10, 11])
+        .mockResolvedValueOnce([100])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([101, 102])
+        .mockResolvedValueOnce([102]);
+
+      mockInstance.fetchMock.mockImplementation(async function* () {
+        yield { uid: 10, envelope: { messageId: '<a@x>' } };
+        yield { uid: 11, envelope: { messageId: '<b@x>' } };
       });
+
+      await imapService.connect(mockAccount);
+      const result = await imapService.findThreadMessages(
+        mockAccount.id, 'Review', 'INBOX',
+      );
+
+      expect(result.messageIds).toEqual(['<a@x>', '<b@x>']);
+      expect(result.uids).toEqual([100, 101, 102]);
+    });
+
+    it('should skip References search when disabled', async () => {
+      mockInstance.searchMock
+        .mockResolvedValueOnce([1])
+        .mockResolvedValueOnce([200]);
+
+      mockInstance.fetchMock.mockImplementation(async function* () {
+        yield { uid: 1, envelope: { messageId: '<x@y>' } };
+      });
+
+      await imapService.connect(mockAccount);
+      const result = await imapService.findThreadMessages(
+        mockAccount.id, 'Review', 'INBOX', { searchReferences: false },
+      );
+
+      expect(mockInstance.searchMock).toHaveBeenCalledTimes(2);
+      expect(result.uids).toEqual([200]);
+    });
+
+    it('should return empty result when source folder is empty', async () => {
+      mockInstance.searchMock.mockResolvedValueOnce([]);
+
+      await imapService.connect(mockAccount);
+      const result = await imapService.findThreadMessages(
+        mockAccount.id, 'EmptyFolder', 'INBOX',
+      );
+
+      expect(result.messageIds).toEqual([]);
+      expect(result.uids).toEqual([]);
+    });
+
+    it('should tolerate per-message search errors', async () => {
+      mockInstance.searchMock
+        .mockResolvedValueOnce([1, 2])
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce([300])
+        .mockResolvedValueOnce([301])
+        .mockResolvedValueOnce([]);
+
+      mockInstance.fetchMock.mockImplementation(async function* () {
+        yield { uid: 1, envelope: { messageId: '<a@x>' } };
+        yield { uid: 2, envelope: { messageId: '<b@x>' } };
+      });
+
+      await imapService.connect(mockAccount);
+      const result = await imapService.findThreadMessages(
+        mockAccount.id, 'Review', 'INBOX',
+      );
+
+      expect(result.uids).toEqual([300, 301]);
     });
   });
 


### PR DESCRIPTION
## Summary

Implements both open feature requests in one PR.

### `imap_create_folder` (closes #64)
New tool to create IMAP folders/mailboxes via the standard `CREATE` command. Most servers also create missing parent folders, so `Archives/2026/2026-05` works in one call. Already-existing folders are treated as success.

### `createDestinationIfMissing` on `imap_move_email` (also #64)
Optional flag that auto-creates the target folder before moving when it does not exist. Closes the silent-failure gap. Tool result reports `destinationCreated` so callers can see what happened.

### `imap_find_thread_messages` (closes #63)
Given a `sourceFolder` of already-sorted thread messages, finds messages in `searchFolder` (default INBOX) that belong to the same conversations via `HEADER` search on `In-Reply-To` and optionally `References`. Pure RFC 3501, works on any IMAP server.

## Tests

19 new tests, 119 total, all passing locally:
- 10 service-level tests covering happy path, edge cases, and error tolerance
- 9 tool-handler tests for the new and updated tools
- README updated for all three changes

## Test plan

- [ ] Manual: create a deep folder path (`Archives/2026/2026-05`) and verify parents are created
- [ ] Manual: move an email with `createDestinationIfMissing: true` to a new folder and verify auto-creation
- [ ] Manual: sort one message of a thread into a folder, run `imap_find_thread_messages` against INBOX, verify replies surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)