### PR TITLE
chore(deps): npm audit fix (closes fast-uri CVSS 7.5 + 3 mid CVEs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,12 +2099,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2123,9 +2123,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2482,9 +2482,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"


### PR DESCRIPTION
## Summary

Schließt 1 high + 3 moderate Dependency-Vulnerabilities, alle transitiv und via `npm audit fix` ohne `--force` lösbar.

- **fast-uri** 3.1.0 → 3.1.2 — GHSA-q3j6-qgpj-74h6 (CVSS 7.5, Path-Traversal via percent-encoded segments) + GHSA-v39h-62p7-jpjc (Host-Confusion)
- **hono** 4.12.12 → 4.12.19 — 6 moderate CVEs (JSX HTML-Injection, JWT NumericDate validation, Cache leakage via Vary header, bodyLimit bypass)
- **ip-address** 10.1.0 → 10.2.0 — GHSA-v2v4-37r5-5v8g (XSS in Address6 HTML methods)
- **express-rate-limit** 8.3.2 → 8.5.2 — transitive ip-address update

`npm audit --omit=dev` vorher: 1 high + 3 moderate · nachher: **0**.

Nur Minor/Patch-Bumps — kein `--force` nötig, keine Major-Breaking-Changes erwartet.

## Test plan

- [x] `npm audit --omit=dev` zeigt 0 vulnerabilities
- [x] `npm run build` läuft durch
- [x] `npm test` grün (5 Test Files, 100 Tests passed)
- [ ] Smoke-Test: Manuelles Triggern eines IMAP-Tools (optional, kein Runtime-Pfad berührt hono/fast-uri direkt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)