### PR TITLE
fix: prevent crash when editing account with non-email username (#73)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -196,10 +196,10 @@ async function handleAccountSubmit(e) {
     
     // Auto-detect provider if not selected
     if (!selectedProvider || selectedProvider.id === 'custom') {
-        const domain = accountData.email.split('@')[1];
-        const detectedProvider = providers.find(p => 
-            p.domains.some(d => domain.endsWith(d))
-        );
+        const domain = (accountData.email || '').split('@')[1]?.toLowerCase();
+        const detectedProvider = domain
+            ? providers.find(p => p.domains.some(d => domain.endsWith(d)))
+            : undefined;
         if (detectedProvider) {
             accountData.host = detectedProvider.imapHost;
             accountData.port = detectedProvider.imapPort;
@@ -424,11 +424,12 @@ async function editAccount(accountId) {
             document.getElementById('smtpSettings').classList.add('hidden');
         }
         
-        // Try to detect provider
-        const domain = account.user.split('@')[1];
-        const detectedProvider = providers.find(p => 
-            p.domains.some(d => domain.endsWith(d))
-        );
+        // Try to detect provider (use email; fall back to user, which may not contain a domain)
+        const detectEmail = account.email || account.user || '';
+        const domain = detectEmail.split('@')[1]?.toLowerCase();
+        const detectedProvider = domain
+            ? providers.find(p => p.domains.some(d => domain.endsWith(d)))
+            : undefined;
         selectedProvider = detectedProvider || providers.find(p => p.id === 'custom');
         
         // Show credentials form


### PR DESCRIPTION
Fixes #73.

## Problem
Editing an account in the web UI failed with:
> Failed to load account: can't access property "endsWith", domain is undefined

## Root cause
`editAccount()` in `public/js/app.js` derived the provider-detection domain from `account.user` via `split('@')[1]` with no guard. The IMAP username is often **not** a full email (e.g. just `michael`) or may be missing, so `domain` became `undefined` and `domain.endsWith()` threw. The surrounding `try/catch` then reported "Failed to load account" — even though the account had loaded correctly.

## Fix
- Derive the domain from `account.email` (falling back to `user`), lowercase it, and guard against a missing domain — mirroring the safe server-side `getProviderByEmail` logic in `src/providers/email-providers.ts`.
- Apply the same guard to the create/auto-detect path (latent bug at the same spot).

## Verification
- `node --check public/js/app.js` passes
- Full test suite: **119/119 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)