### PR TITLE
fix: serve setup wizard assets when running via npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "dist",
+    "public",
     "README.md",
     "LICENSE"
   ],

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import bodyParser from 'body-parser';
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import open from 'open';
 import { AccountManager } from '../services/account-manager.js';
@@ -31,7 +32,20 @@ export class WebUIServer {
   private setupMiddleware(): void {
     this.app.use(cors());
     this.app.use(bodyParser.json());
-    this.app.use(express.static(path.join(__dirname, '../../public')));
+    this.app.use(express.static(this.resolvePublicDir()));
+  }
+
+  // The bundled entrypoint may live at dist/web/server.js (npm run web) or be
+  // inlined into dist/setup.js, so __dirname differs. Probe the likely
+  // locations and fall back to the current working directory.
+  private resolvePublicDir(): string {
+    const candidates = [
+      path.join(__dirname, '../../public'),
+      path.join(__dirname, '../public'),
+      path.join(process.cwd(), 'public'),
+    ];
+    const found = candidates.find(dir => fs.existsSync(path.join(dir, 'index.html')));
+    return found ?? candidates[0];
   }
 
   private setupRoutes(): void {


### PR DESCRIPTION
Fixes the setup wizard returning **`Cannot GET /`** when launched via `npx -p imap-mcp-server imap-setup` (reported after the 1.2.1 release).

## Root cause
1. The `files` whitelist shipped only `dist/`, so `public/` (the web UI — `index.html`, `js/app.js`) was **missing from the published npm package**.
2. The static-file path was hardcoded to `../../public`. That's correct for `dist/web/server.js`, but the wizard runs `dist/setup.js` (with the web server bundled in), where `__dirname` is `dist/` — so `../../public` pointed *above* the package root.

## Fix
- Add `public` to the `files` whitelist.
- Resolve the static dir by probing the likely locations (`../../public`, `../public`, `cwd/public`) for `index.html`, instead of assuming one layout.

## Verification
End-to-end (`npm pack` → install in a clean dir → run `imap-setup`):
- `public/index.html` + `public/js/app.js` now included in the tarball
- `GET /` → **200 text/html** (HTML served, no more "Cannot GET /")
- Test suite: **119/119 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)