### PR TITLE
chore: improve MCP discoverability, trust & usability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+Cross-agent project guide for **imap-mcp-server** — a Model Context Protocol (MCP)
+server that gives AI assistants (Claude, ChatGPT, Cursor, …) access to IMAP/SMTP
+mailboxes. This file is the shared source of truth for any agent or contributor
+working in this repository.
+
+## Architecture
+
+- **Entry point** — `src/index.ts` boots an `McpServer` (MCP SDK) over **stdio**
+  and registers all tools via `src/tools/index.ts`.
+- **Services** (`src/services/`):
+  - `ImapService` — IMAP protocol via **`imapflow`**, with connection pooling,
+    folder operations, search, fetch, move/delete, append (Sent/Drafts).
+  - `SmtpService` — outbound mail via **`nodemailer`**; composes raw MIME and sends.
+  - `AccountManager` — account CRUD with **AES-256-CBC** encrypted credential
+    storage at `~/.imap-mcp/accounts.json` (key at `~/.imap-mcp/.key`).
+  - `SpamService` — disposable/known-spam domain detection.
+- **Tools** (`src/tools/`), grouped by area:
+  - `account-tools.ts` — add / update / list / remove / connect / disconnect / test.
+  - `email-tools.ts` — search, get, latest, send, reply, forward, save draft,
+    mark read/unread, delete, bulk delete, move, attachments, upload, threads.
+  - `folder-tools.ts` — list, status, create, unread counts.
+  - `spam-tools.ts` — spam analysis, domain stats, allow/deny lists.
+- **Web setup wizard** — `src/web/server.ts` (Express) serves `public/` for
+  account onboarding (`npm run setup` / `imap-setup`).
+- **Types** — `src/types/index.ts`.
+- All tools return **JSON-formatted text** content; errors are returned as
+  structured JSON where practical rather than thrown for caller-facing failures.
+
+## Build / Test commands
+
+```bash
+npm install          # install dependencies
+npm run build        # bundle to dist/ via esbuild (build.mjs)
+npm test             # run the vitest suite (run mode)
+npm run test:watch   # vitest in watch mode
+npm run lint         # tsc --noEmit type-check
+npm run dev          # run the server from source (tsx watch)
+npm run setup        # launch the web setup wizard
+```
+
+Always run `npm run build` **and** `npm test` before committing changes that
+touch `src/`. Keep the suite green (currently 119 tests).
+
+## Security rules (must follow)
+
+1. **Never log secrets.** Passwords, encryption keys, `accounts.json` contents,
+   raw auth tokens, and full message bodies must not be written to stdout/stderr
+   or to disk outside the user's mailbox/download directories. When adding logs,
+   log identifiers (account id, folder, uid), not credentials.
+2. **No destructive mail operations without explicit guard logic.** Deletes,
+   bulk deletes, and moves must be driven by explicit caller input. Bulk/criteria
+   deletion must keep its `dryRun` path and require concrete criteria — never
+   delete a whole folder by default, and never widen a delete beyond what the
+   caller specified.
+3. **Tool schema changes require docs + tests.** Do not rename existing tools or
+   change their input/output shape without (a) updating the tool `description`,
+   (b) updating `README.md`, and (c) adding/adjusting tests. Prefer additive,
+   backward-compatible changes (new optional fields) over breaking ones.
+4. **Credentials stay local.** Do not add telemetry, analytics, crash reporting,
+   or any third-party network calls. The only outbound connections are to the
+   user's own IMAP/SMTP servers.
+5. **Validate and sanitize file paths** for attachment upload/download (already
+   done via `path.basename`); keep writes confined to the configured directories.
+
+## Conventions
+
+- TypeScript, ESM (`"type": "module"`), Node ≥ 18.
+- Tool names are stable public API: `imap_*`. Do not rename without a strong
+  reason and a migration note.
+- Zod schemas describe every tool input; every field gets a `.describe()` that
+  tells an LLM **when and how** to use it.
+- Match the surrounding code style; keep error handling and connection cleanup
+  consistent with existing tools.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,45 +1,21 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
 
-## Project Overview
+The full, agent-agnostic project guide — architecture, build/test commands,
+security rules, and conventions — lives in **@AGENTS.md**. Read it first.
 
-This is an IMAP MCP (Model Context Protocol) server built with TypeScript that provides comprehensive IMAP email integration with secure account management and connection pooling.
+## Claude-specific notes
 
-## Common Development Commands
-
-- Build the project: `npm run build`
-- Run in development mode: `npm run dev`
-- Start the compiled server: `npm start`
-- Install dependencies: `npm install`
-
-## Architecture
-
-### Core Components
-
-1. **MCP Server (`src/index.ts`)**: The main entry point that sets up the MCP server using the McpServer class from the MCP SDK.
-
-2. **Services**:
-   - `ImapService`: Manages IMAP connections, email operations, and folder management with connection pooling
-   - `AccountManager`: Handles secure account storage with AES-256 encryption
-
-3. **Tools**: MCP tools are organized into three categories:
-   - `account-tools.ts`: Account management (add, remove, list, connect, disconnect)
-   - `email-tools.ts`: Email operations (search, read, download attachments, mark, delete, move, bulk delete, send, reply, forward)
-   - `folder-tools.ts`: Folder operations (list, status, unread counts)
-
-### Key Design Decisions
-
-- Uses `node-imap` for IMAP protocol implementation
-- Implements connection pooling to efficiently manage multiple IMAP connections
-- Stores encrypted credentials in `~/.imap-mcp/accounts.json`
-- All MCP tools return JSON-formatted text responses
-- TypeScript for type safety with comprehensive type definitions in `src/types/`
-
-## Adding New Features
-
-When adding new IMAP operations:
-1. Add the operation to the appropriate service (`ImapService`)
-2. Create or update the corresponding tool in the tools directory
-3. Ensure proper error handling and connection management
-4. Update types if needed in `src/types/index.ts`
+- This is an IMAP/SMTP **MCP server** (TypeScript, ESM). It uses **`imapflow`**
+  for IMAP and **`nodemailer`** for SMTP. (It does **not** use `node-imap`.)
+- Credentials are stored AES-256 encrypted under `~/.imap-mcp/`; all tools
+  return JSON-formatted text.
+- When adding an IMAP/SMTP operation:
+  1. Implement it in the relevant service (`ImapService` / `SmtpService`).
+  2. Expose it via the matching tool file in `src/tools/`.
+  3. Keep tool names (`imap_*`) stable; write LLM-oriented `.describe()` text.
+  4. Update types in `src/types/index.ts`, plus `README.md` and tests.
+- Before committing `src/` changes: `npm run build && npm test` (keep it green).
+- Follow the security rules in @AGENTS.md — no secret logging, no telemetry,
+  no destructive mail ops without explicit guard logic.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ Add the IMAP MCP server to your Claude Desktop configuration file:
 
 Once configured, the IMAP MCP server provides the following tools in Claude:
 
+> **Choosing an account.** For the email and folder tools, `accountId` is
+> **optional** and backward-compatible. You may instead pass `accountName`, and
+> if you only have a **single** account configured you can omit both — that
+> account is used by default. With multiple accounts and no selector, the tool
+> returns a clear error listing your options (`imap_list_accounts`).
+
 ### Account Management
 
 - **imap_add_account**: Add a new IMAP account

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,48 @@
+# Security Policy
+
+`imap-mcp-server` connects AI assistants to your email. Because email is highly
+sensitive, the project is designed to keep your data **local and under your
+control**.
+
+## Security model
+
+- **Local execution.** The server runs entirely on your own machine as a local
+  MCP process (stdio). It is not a hosted service and does not require any
+  account with this project.
+- **Credential storage.** IMAP/SMTP credentials are stored encrypted with
+  **AES-256-CBC** in `~/.imap-mcp/accounts.json`. The encryption key is generated
+  locally and kept at `~/.imap-mcp/.key`. Protect these files with your OS user
+  permissions; anyone who can read both files can read your credentials.
+- **No telemetry.** The server collects no analytics, usage data, or crash
+  reports.
+- **No third-party data sharing.** The only outbound network connections are to
+  the IMAP and SMTP servers **you** configure. Email content and credentials are
+  never sent anywhere else.
+- **Your MCP client sees your mail.** Email content returned by these tools is
+  passed to whichever MCP client/LLM you connect (e.g. Claude, ChatGPT, Cursor).
+  Review that client's own privacy terms; treat any connected model as a party
+  that can read the mailboxes you expose.
+
+## Recommendations for users
+
+- Use **app-specific passwords** where your provider supports them (Gmail,
+  iCloud, Yahoo, Fastmail, …) instead of your primary password.
+- Keep `~/.imap-mcp/` readable only by your user account.
+- Prefer least-privilege accounts/folders when possible.
+- Be deliberate with destructive tools (`imap_delete_email`,
+  `imap_bulk_delete`, `imap_bulk_delete_by_search`) — use the `dryRun` option to
+  preview criteria-based deletions first.
+
+## Reporting a vulnerability (responsible disclosure)
+
+If you discover a security issue, please report it **privately** — do not open a
+public issue with exploit details.
+
+- Use GitHub's **[Report a vulnerability](https://github.com/nikolausm/imap-mcp-server/security/advisories/new)**
+  (Security → Advisories) to open a private advisory, **or**
+- Contact the maintainer via the email on the
+  [GitHub profile](https://github.com/nikolausm).
+
+Please include reproduction steps and affected versions. We aim to acknowledge
+reports promptly, investigate, and ship a fix with a coordinated disclosure once
+a patch is available. Thank you for helping keep users safe.

--- a/package.json
+++ b/package.json
@@ -30,11 +30,17 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "imap",
+    "smtp",
     "email",
+    "mail",
     "claude",
+    "chatgpt",
+    "cursor",
     "ai",
-    "model-context-protocol"
+    "llm",
+    "agent"
   ],
   "author": "Michael Nikolaus",
   "license": "MIT",

--- a/src/services/account-manager.ts
+++ b/src/services/account-manager.ts
@@ -132,6 +132,43 @@ export class AccountManager {
     });
   }
 
+  /**
+   * Resolve which account a tool call refers to, in a backward-compatible way:
+   *   1. explicit `accountId`        → must exist
+   *   2. explicit `accountName`      → matched by name
+   *   3. neither, and exactly ONE account configured → that account (default)
+   * Throws a helpful, actionable error otherwise. Returns the account id.
+   */
+  resolveAccountId(accountId?: string, accountName?: string): string {
+    this.loadAccountsSync();
+
+    if (accountId) {
+      if (!this.accounts.has(accountId)) {
+        throw new Error(`Account ${accountId} not found. Use imap_list_accounts to see available accounts.`);
+      }
+      return accountId;
+    }
+
+    if (accountName) {
+      const match = Array.from(this.accounts.values()).find(acc => acc.name === accountName);
+      if (!match) {
+        throw new Error(`No account named "${accountName}". Use imap_list_accounts to see available accounts.`);
+      }
+      return match.id;
+    }
+
+    const all = Array.from(this.accounts.values());
+    if (all.length === 1) {
+      return all[0].id;
+    }
+    if (all.length === 0) {
+      throw new Error('No accounts configured. Add one with imap_add_account (or run the setup wizard).');
+    }
+    throw new Error(
+      `Multiple accounts are configured (${all.length}). Specify accountId or accountName. Use imap_list_accounts to see them.`
+    );
+  }
+
   getAccountByName(name: string): ImapAccount | undefined {
     const account = Array.from(this.accounts.values()).find(acc => acc.name === name);
     if (!account) return undefined;

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -7,6 +7,13 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 
+// Reusable, backward-compatible account selector. accountId stays accepted as
+// before; accountName and the single-account default are additive conveniences.
+const accountSelector = {
+  accountId: z.string().optional().describe('Account ID (from imap_list_accounts). Optional if accountName is given or only one account is configured.'),
+  accountName: z.string().optional().describe('Account name instead of accountId. Optional if accountId is given or only one account is configured.'),
+};
+
 const DOWNLOAD_DIR = process.env.IMAP_DOWNLOAD_DIR || join(homedir(), 'Downloads', 'imap-attachments');
 const MAX_UPLOAD_SIZE = parseInt(process.env.IMAP_MAX_UPLOAD_SIZE ?? '', 10) || 25 * 1024 * 1024;
 const UPLOAD_TTL_MS = parseInt(process.env.IMAP_UPLOAD_TTL_MS ?? '', 10) || 24 * 60 * 60 * 1000;
@@ -30,7 +37,7 @@ export function emailTools(
   server.registerTool('imap_search_emails', {
     description: 'Search a mailbox folder for emails matching criteria (sender, recipient, subject, body text, date range, read/flagged status). Use this to FIND messages when you know something about them but not their UID — e.g. "emails from amazon last week", "unread invoices". Returns lightweight headers (uid, from, subject, date); call imap_get_email with a returned uid to read full content. For the newest messages without criteria, prefer imap_get_latest_emails.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name (default: INBOX)'),
       from: z.string().optional().describe('Search by sender'),
       to: z.string().optional().describe('Search by recipient'),
@@ -42,7 +49,8 @@ export function emailTools(
       flagged: z.boolean().optional().describe('Filter by flagged status'),
       limit: z.coerce.number().optional().default(50).describe('Maximum number of results'),
     }
-  }, async ({ accountId, folder, limit, ...searchCriteria }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, limit, ...searchCriteria }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const criteria: any = {};
     
     if (searchCriteria.from) criteria.from = searchCriteria.from;
@@ -73,7 +81,7 @@ export function emailTools(
   server.registerTool('imap_get_email', {
     description: 'Read the FULL content of a single email by its UID (plain text + HTML body, sender/recipients, date, attachment list, optional raw headers and text-attachment previews). Use after imap_search_emails or imap_get_latest_emails gives you a uid. Body text is truncated to maxContentLength to protect the context window — raise it for long messages. To fetch attachment bytes, use imap_download_attachment.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
       maxContentLength: z.coerce.number().default(10000).describe('Maximum characters to return for text and HTML body content'),
@@ -81,7 +89,8 @@ export function emailTools(
       maxAttachmentTextChars: z.coerce.number().default(100000).describe('Maximum characters to return per text attachment'),
       includeHeaders: z.boolean().default(false).describe('Include raw email headers (e.g. List-Unsubscribe, List-Unsubscribe-Post)'),
     }
-  }, async ({ accountId, folder, uid, maxContentLength, includeAttachmentText, maxAttachmentTextChars, includeHeaders }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, maxContentLength, includeAttachmentText, maxAttachmentTextChars, includeHeaders }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const email = await imapService.getEmailContent(accountId, folder, uid, {
       includeAttachmentText,
       maxAttachmentTextChars,
@@ -174,14 +183,15 @@ export function emailTools(
   server.registerTool('imap_download_attachment', {
     description: 'Download a single attachment from an email (folder + uid + attachment filename/contentId, as listed by imap_get_email). Images are returned inline for viewing; PDFs are saved and their text is extracted inline (extractText); other files are saved to the shared downloads directory (or savePath). Use when the user wants the actual file contents, not just the message body.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
       filename: z.string().describe('Attachment filename or contentId'),
       savePath: z.string().optional().describe('Optional file path to save the attachment to. If not provided, files are saved to the shared downloads directory.'),
       extractText: z.boolean().default(true).describe('For PDFs, extract and return text content inline'),
     }
-  }, async ({ accountId, folder, uid, filename, savePath, extractText }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, filename, savePath, extractText }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const { content, contentType, filename: resolvedFilename } = await imapService.getAttachmentContent(accountId, folder, uid, filename);
 
     const isImage = contentType.startsWith('image/');
@@ -264,11 +274,12 @@ export function emailTools(
   server.registerTool('imap_mark_as_read', {
     description: 'Mark an email as read',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
     }
-  }, async ({ accountId, folder, uid }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     await imapService.markAsRead(accountId, folder, uid);
     
     return {
@@ -286,11 +297,12 @@ export function emailTools(
   server.registerTool('imap_mark_as_unread', {
     description: 'Mark an email as unread',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
     }
-  }, async ({ accountId, folder, uid }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     await imapService.markAsUnread(accountId, folder, uid);
     
     return {
@@ -308,11 +320,12 @@ export function emailTools(
   server.registerTool('imap_delete_email', {
     description: 'Delete ONE email by folder + uid (moves to Trash or expunges, server-dependent). Destructive and not easily undone — confirm the user means this specific message. To remove many at once use imap_bulk_delete (known uids) or imap_bulk_delete_by_search (by criteria, supports dryRun). To file an email away instead of deleting, use imap_move_email.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
     }
-  }, async ({ accountId, folder, uid }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     await imapService.deleteEmail(accountId, folder, uid);
 
     return {
@@ -330,13 +343,14 @@ export function emailTools(
   server.registerTool('imap_move_email', {
     description: 'Move an email from one folder to another (e.g., INBOX to Taxes, or INBOX to Archive). Optionally creates the destination folder if it does not exist.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Source folder name'),
       uid: z.coerce.number().describe('Email UID'),
       targetFolder: z.string().describe('Destination folder name'),
       createDestinationIfMissing: z.boolean().optional().describe('If true, create the destination folder before moving when it does not exist (default: false)'),
     }
-  }, async ({ accountId, folder, uid, targetFolder, createDestinationIfMissing }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, targetFolder, createDestinationIfMissing }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     try {
       const result = await imapService.moveEmail(accountId, folder, uid, targetFolder, {
         createDestinationIfMissing,
@@ -379,12 +393,13 @@ export function emailTools(
   server.registerTool('imap_bulk_delete', {
     description: 'Delete multiple emails at once with chunking and auto-reconnection. Processes deletions in batches to prevent connection timeouts.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uids: z.array(z.coerce.number()).describe('Array of email UIDs to delete'),
       chunkSize: z.coerce.number().default(50).describe('Number of emails to delete per batch (default: 50)'),
     }
-  }, async ({ accountId, folder, uids, chunkSize }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uids, chunkSize }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const result = await imapService.bulkDelete(accountId, folder, uids, chunkSize);
 
     return {
@@ -408,7 +423,7 @@ export function emailTools(
   server.registerTool('imap_bulk_delete_by_search', {
     description: 'Search for emails matching criteria and delete them all. Useful for cleaning up spam or unwanted emails.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       from: z.string().optional().describe('Delete emails from this sender'),
       to: z.string().optional().describe('Delete emails to this recipient'),
@@ -418,7 +433,8 @@ export function emailTools(
       chunkSize: z.coerce.number().default(50).describe('Number of emails to delete per batch'),
       dryRun: z.boolean().default(false).describe('If true, only return what would be deleted without actually deleting'),
     }
-  }, async ({ accountId, folder, from, to, subject, before, since, chunkSize, dryRun }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, from, to, subject, before, since, chunkSize, dryRun }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const criteria: any = {};
     if (from) criteria.from = from;
     if (to) criteria.to = to;
@@ -489,11 +505,12 @@ export function emailTools(
   server.registerTool('imap_get_latest_emails', {
     description: 'Get the most recent emails from a folder, newest first. Use this for "what just came in?" / "show my latest inbox messages" when no search filter is needed. Returns lightweight headers (uid, from, subject, date); read a specific one with imap_get_email. To filter by sender/subject/date instead, use imap_search_emails.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       count: z.coerce.number().default(10).describe('Number of emails to retrieve'),
     }
-  }, async ({ accountId, folder, count }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, count }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const sortedMessages = await imapService.getLatestEmails(accountId, folder, count);
     
     return {
@@ -510,7 +527,7 @@ export function emailTools(
   server.registerTool('imap_send_email', {
     description: 'Compose and send a NEW email via the account\'s SMTP server (a copy is saved to Sent unless disabled). Use for fresh outbound messages. To respond to an existing message use imap_reply_to_email (keeps threading); to pass a message on use imap_forward_email; to store without sending use imap_save_draft. Supports to/cc/bcc, text and/or HTML, and attachments by base64 content or by file path (see imap_upload_file for large files).',
     inputSchema: {
-      accountId: z.string().describe('Account ID to send from'),
+      ...accountSelector,
       to: z.union([z.string(), z.array(z.string())]).describe('Recipient email address(es)'),
       subject: z.string().describe('Email subject'),
       text: z.string().optional().describe('Plain text content'),
@@ -525,7 +542,8 @@ export function emailTools(
         contentType: z.string().optional().describe('MIME type'),
       })).optional().describe('Email attachments'),
     }
-  }, async ({ accountId, to, subject, text, html, cc, bcc, replyTo, attachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, to, subject, text, html, cc, bcc, replyTo, attachments }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
@@ -575,7 +593,7 @@ export function emailTools(
   server.registerTool('imap_save_draft', {
     description: 'Save an email as a draft in the Drafts folder (no send). Takes the same fields as imap_send_email.',
     inputSchema: {
-      accountId: z.string().describe('Account ID to save the draft under'),
+      ...accountSelector,
       to: z.union([z.string(), z.array(z.string())]).optional().describe('Recipient email address(es)'),
       subject: z.string().optional().describe('Email subject'),
       text: z.string().optional().describe('Plain text content'),
@@ -593,7 +611,8 @@ export function emailTools(
       })).optional().describe('Email attachments'),
       folder: z.string().optional().describe('Override the Drafts folder name (defaults to auto-detected Drafts folder)'),
     }
-  }, async ({ accountId, to, subject, text, html, cc, bcc, replyTo, inReplyTo, references, attachments, folder }) => {
+  }, async ({ accountId: rawAccountId, accountName, to, subject, text, html, cc, bcc, replyTo, inReplyTo, references, attachments, folder }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
@@ -646,7 +665,7 @@ export function emailTools(
   server.registerTool('imap_reply_to_email', {
     description: 'Reply to an existing email identified by folder + uid. Automatically sets the recipient to the original sender, prefixes the subject with "Re:", and preserves threading (In-Reply-To/References). Set replyAll to also include the original recipients. Use this instead of imap_send_email whenever the user is responding to a message already in a mailbox.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder containing the original email'),
       uid: z.coerce.number().describe('UID of the email to reply to'),
       text: z.string().optional().describe('Plain text reply content'),
@@ -659,7 +678,8 @@ export function emailTools(
         contentType: z.string().optional().describe('MIME type'),
       })).optional().describe('Email attachments'),
     }
-  }, async ({ accountId, folder, uid, text, html, replyAll, attachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, text, html, replyAll, attachments }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
@@ -718,14 +738,15 @@ export function emailTools(
   server.registerTool('imap_forward_email', {
     description: 'Forward an existing email (folder + uid) to new recipients, quoting the original message and headers. Optionally include the original attachments. Use when the user wants to pass an existing message on to someone else; use imap_reply_to_email instead to respond to the sender.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder containing the original email'),
       uid: z.coerce.number().describe('UID of the email to forward'),
       to: z.union([z.string(), z.array(z.string())]).describe('Forward to email address(es)'),
       text: z.string().optional().describe('Additional text to include'),
       includeAttachments: z.boolean().default(true).describe('Include original attachments'),
     }
-  }, async ({ accountId, folder, uid, to, text, includeAttachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, to, text, includeAttachments }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
@@ -775,12 +796,13 @@ export function emailTools(
       'Find messages in `searchFolder` that belong to the same conversation threads as messages already in `sourceFolder`. ' +
       'Useful for catching replies that arrived after a thread was sorted. Works on any IMAP server (uses RFC 3501 HEADER search on In-Reply-To and References).',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       sourceFolder: z.string().describe('Folder containing the already-sorted thread messages (e.g. "Review.Articles")'),
       searchFolder: z.string().default('INBOX').describe('Folder to search for related thread messages (default: INBOX)'),
       searchReferences: z.boolean().optional().describe('Also search the References header for multi-level threads (default: true)'),
     }
-  }, async ({ accountId, sourceFolder, searchFolder, searchReferences }) => {
+  }, async ({ accountId: rawAccountId, accountName, sourceFolder, searchFolder, searchReferences }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     try {
       const result = await imapService.findThreadMessages(accountId, sourceFolder, searchFolder, {
         searchReferences,

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -28,7 +28,7 @@ export function emailTools(
 
   // Search emails tool
   server.registerTool('imap_search_emails', {
-    description: 'Search for emails in a folder',
+    description: 'Search a mailbox folder for emails matching criteria (sender, recipient, subject, body text, date range, read/flagged status). Use this to FIND messages when you know something about them but not their UID — e.g. "emails from amazon last week", "unread invoices". Returns lightweight headers (uid, from, subject, date); call imap_get_email with a returned uid to read full content. For the newest messages without criteria, prefer imap_get_latest_emails.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name (default: INBOX)'),
@@ -71,7 +71,7 @@ export function emailTools(
 
   // Get email content tool
   server.registerTool('imap_get_email', {
-    description: 'Get the full content of an email, with optional text attachment previews',
+    description: 'Read the FULL content of a single email by its UID (plain text + HTML body, sender/recipients, date, attachment list, optional raw headers and text-attachment previews). Use after imap_search_emails or imap_get_latest_emails gives you a uid. Body text is truncated to maxContentLength to protect the context window — raise it for long messages. To fetch attachment bytes, use imap_download_attachment.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
@@ -172,7 +172,7 @@ export function emailTools(
 
   // Download attachment tool
   server.registerTool('imap_download_attachment', {
-    description: 'Download an attachment from an email. Returns image content directly for image attachments, extracts text from PDFs, or saves to a shared downloads directory accessible from the host.',
+    description: 'Download a single attachment from an email (folder + uid + attachment filename/contentId, as listed by imap_get_email). Images are returned inline for viewing; PDFs are saved and their text is extracted inline (extractText); other files are saved to the shared downloads directory (or savePath). Use when the user wants the actual file contents, not just the message body.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
@@ -306,7 +306,7 @@ export function emailTools(
 
   // Delete email tool
   server.registerTool('imap_delete_email', {
-    description: 'Delete an email (moves to trash or expunges)',
+    description: 'Delete ONE email by folder + uid (moves to Trash or expunges, server-dependent). Destructive and not easily undone — confirm the user means this specific message. To remove many at once use imap_bulk_delete (known uids) or imap_bulk_delete_by_search (by criteria, supports dryRun). To file an email away instead of deleting, use imap_move_email.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
@@ -487,7 +487,7 @@ export function emailTools(
 
   // Get latest emails tool
   server.registerTool('imap_get_latest_emails', {
-    description: 'Get the latest emails from a folder',
+    description: 'Get the most recent emails from a folder, newest first. Use this for "what just came in?" / "show my latest inbox messages" when no search filter is needed. Returns lightweight headers (uid, from, subject, date); read a specific one with imap_get_email. To filter by sender/subject/date instead, use imap_search_emails.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
@@ -508,7 +508,7 @@ export function emailTools(
 
   // Send email tool
   server.registerTool('imap_send_email', {
-    description: 'Send an email using SMTP',
+    description: 'Compose and send a NEW email via the account\'s SMTP server (a copy is saved to Sent unless disabled). Use for fresh outbound messages. To respond to an existing message use imap_reply_to_email (keeps threading); to pass a message on use imap_forward_email; to store without sending use imap_save_draft. Supports to/cc/bcc, text and/or HTML, and attachments by base64 content or by file path (see imap_upload_file for large files).',
     inputSchema: {
       accountId: z.string().describe('Account ID to send from'),
       to: z.union([z.string(), z.array(z.string())]).describe('Recipient email address(es)'),
@@ -644,7 +644,7 @@ export function emailTools(
 
   // Reply to email tool
   server.registerTool('imap_reply_to_email', {
-    description: 'Reply to an existing email',
+    description: 'Reply to an existing email identified by folder + uid. Automatically sets the recipient to the original sender, prefixes the subject with "Re:", and preserves threading (In-Reply-To/References). Set replyAll to also include the original recipients. Use this instead of imap_send_email whenever the user is responding to a message already in a mailbox.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder containing the original email'),
@@ -716,7 +716,7 @@ export function emailTools(
 
   // Forward email tool
   server.registerTool('imap_forward_email', {
-    description: 'Forward an existing email',
+    description: 'Forward an existing email (folder + uid) to new recipients, quoting the original message and headers. Optionally include the original attachments. Use when the user wants to pass an existing message on to someone else; use imap_reply_to_email instead to respond to the sender.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder containing the original email'),

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -10,7 +10,7 @@ export function folderTools(
 ): void {
   // List folders tool
   server.registerTool('imap_list_folders', {
-    description: 'List all folders/mailboxes in an IMAP account',
+    description: 'List all folders/mailboxes for an account (names, hierarchy delimiter, attributes). Use this first to discover exact folder names before searching, moving, or creating subfolders — folder naming varies by provider (e.g. "Archive" vs "[Gmail]/All Mail" vs "INBOX.Archive").',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
     }
@@ -104,7 +104,7 @@ export function folderTools(
 
   // Get unread count tool
   server.registerTool('imap_get_unread_count', {
-    description: 'Get the count of unread emails in specified folders',
+    description: 'Count unread (unseen) emails per folder, plus a total. Use for "how many unread do I have?" overviews. Defaults to all folders; pass a folders list to limit scope and speed it up.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folders: z.array(z.string()).optional().describe('List of folders to check (default: all)'),

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -3,6 +3,13 @@ import { ImapService } from '../services/imap-service.js';
 import { AccountManager } from '../services/account-manager.js';
 import { z } from 'zod';
 
+// Backward-compatible account selector (accountId stays accepted; accountName
+// and the single-account default are additive conveniences).
+const accountSelector = {
+  accountId: z.string().optional().describe('Account ID (from imap_list_accounts). Optional if accountName is given or only one account is configured.'),
+  accountName: z.string().optional().describe('Account name instead of accountId. Optional if accountId is given or only one account is configured.'),
+};
+
 export function folderTools(
   server: McpServer,
   imapService: ImapService,
@@ -12,9 +19,10 @@ export function folderTools(
   server.registerTool('imap_list_folders', {
     description: 'List all folders/mailboxes for an account (names, hierarchy delimiter, attributes). Use this first to discover exact folder names before searching, moving, or creating subfolders — folder naming varies by provider (e.g. "Archive" vs "[Gmail]/All Mail" vs "INBOX.Archive").',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
     }
-  }, async ({ accountId }) => {
+  }, async ({ accountId: rawAccountId, accountName }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const folders = await imapService.listFolders(accountId);
     
     return {
@@ -36,10 +44,11 @@ export function folderTools(
   server.registerTool('imap_folder_status', {
     description: 'Get status information about a folder',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().describe('Folder name'),
     }
-  }, async ({ accountId, folder }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const box = await imapService.selectFolder(accountId, folder);
     
     return {
@@ -68,10 +77,11 @@ export function folderTools(
       '(e.g. creating "Archives/2026/2026-05" auto-creates "Archives" and "Archives/2026"). ' +
       'Returns success even if the folder already exists.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folder: z.string().describe('Full folder path to create (e.g. "Archives/2026/2026-05" or "INBOX.Archive")'),
     }
-  }, async ({ accountId, folder }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     try {
       const result = await imapService.createFolder(accountId, folder);
       return {
@@ -106,10 +116,11 @@ export function folderTools(
   server.registerTool('imap_get_unread_count', {
     description: 'Count unread (unseen) emails per folder, plus a total. Use for "how many unread do I have?" overviews. Defaults to all folders; pass a folders list to limit scope and speed it up.',
     inputSchema: {
-      accountId: z.string().describe('Account ID'),
+      ...accountSelector,
       folders: z.array(z.string()).optional().describe('List of folders to check (default: all)'),
     }
-  }, async ({ accountId, folders }) => {
+  }, async ({ accountId: rawAccountId, accountName, folders }) => {
+    const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const allFolders = await imapService.listFolders(accountId);
     const foldersToCheck = folders || allFolders.map(f => f.name);
     

--- a/tests/account-manager.test.ts
+++ b/tests/account-manager.test.ts
@@ -225,6 +225,54 @@ describe('AccountManager', () => {
     });
   });
 
+  describe('resolveAccountId', () => {
+    const addOne = (manager: AccountManager, name: string) => manager.addAccount({
+      name, host: 'imap.test.com', port: 993, user: `${name}@test.com`, password: 'pw', tls: true,
+    });
+
+    it('returns the id when an explicit accountId exists', async () => {
+      const manager = new AccountManager();
+      const created = await addOne(manager, 'A');
+      expect(manager.resolveAccountId(created.id)).toBe(created.id);
+    });
+
+    it('throws for an unknown accountId', async () => {
+      const manager = new AccountManager();
+      await addOne(manager, 'A');
+      expect(() => manager.resolveAccountId('nope')).toThrow(/not found/i);
+    });
+
+    it('resolves by accountName', async () => {
+      const manager = new AccountManager();
+      const created = await addOne(manager, 'Work');
+      expect(manager.resolveAccountId(undefined, 'Work')).toBe(created.id);
+    });
+
+    it('throws for an unknown accountName', async () => {
+      const manager = new AccountManager();
+      await addOne(manager, 'Work');
+      expect(() => manager.resolveAccountId(undefined, 'Home')).toThrow(/no account named/i);
+    });
+
+    it('defaults to the only account when none is specified', async () => {
+      const manager = new AccountManager();
+      const created = await addOne(manager, 'Solo');
+      expect(manager.resolveAccountId()).toBe(created.id);
+    });
+
+    it('throws when no accounts are configured', () => {
+      const manager = new AccountManager();
+      expect(() => manager.resolveAccountId()).toThrow(/no accounts configured/i);
+    });
+
+    it('throws when multiple accounts exist and none is specified', async () => {
+      const manager = new AccountManager();
+      await addOne(manager, 'A');
+      await addOne(manager, 'B');
+      expect(() => manager.resolveAccountId()).toThrow(/multiple accounts/i);
+    });
+  });
+
   describe('removeAccount', () => {
     it('should remove existing account', async () => {
       const manager = new AccountManager();

--- a/tests/email-tools-move.test.ts
+++ b/tests/email-tools-move.test.ts
@@ -16,7 +16,7 @@ const mockImapService = {
   moveEmail: vi.fn(),
 };
 
-const mockAccountManager = {};
+const mockAccountManager = { resolveAccountId: (id: string) => id };
 const mockSmtpService = {};
 
 describe('imap_move_email Tool Handler', () => {

--- a/tests/email-tools-thread.test.ts
+++ b/tests/email-tools-thread.test.ts
@@ -18,7 +18,7 @@ const mockImapService = {
 describe('imap_find_thread_messages Tool Handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    emailTools(mockServer as any, mockImapService as any, {} as any, {} as any);
+    emailTools(mockServer as any, mockImapService as any, { resolveAccountId: (id: string) => id } as any, {} as any);
   });
 
   it('should be registered', () => {

--- a/tests/folder-tools-create.test.ts
+++ b/tests/folder-tools-create.test.ts
@@ -18,7 +18,7 @@ const mockImapService = {
 describe('imap_create_folder Tool Handler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    folderTools(mockServer as any, mockImapService as any, {} as any);
+    folderTools(mockServer as any, mockImapService as any, { resolveAccountId: (id: string) => id } as any);
   });
 
   it('should be registered', () => {


### PR DESCRIPTION
Improves discoverability, trustworthiness, and usability for Claude/ChatGPT/Cursor and other MCP clients. Small, reviewable commits.

## Changes
1. **package.json** — broadened `keywords` (adds `smtp`, `chatgpt`, `cursor`, `mail`, `llm`, `agent`). Repository/bugs/homepage already point to `nikolausm`; license already MIT; `mcpName` already present.
2. **AGENTS.md** (new) — cross-agent project guide: architecture, build/test commands, and **security rules** (no secret logging, no destructive mail ops without explicit guard logic, tool-schema changes require docs+tests, no telemetry/third-party calls).
3. **CLAUDE.md** — slimmed; imports `@AGENTS.md`; removed the outdated `node-imap` mention (project uses **imapflow** + **nodemailer**).
4. **SECURITY.md** (new) — local execution, AES-256 credential storage, no telemetry, no third-party sharing, responsible-disclosure process.
5. **Tool descriptions** — rewritten so an LLM knows *when* to pick each tool and how they relate (search vs latest vs get; send vs reply vs forward vs draft; delete vs bulk-delete vs move; attachment download). **No tool renames, no schema-shape breaks.**
6. **Account selection** — new `AccountManager.resolveAccountId(accountId?, accountName?)` wired into all email + folder tools. `accountId` stays accepted; callers may now pass `accountName`, or omit both when exactly one account is configured. Backward compatible; multi-account ambiguity returns an actionable error. 7 new unit tests.
7. (server.json) — see note below.

## Verification
- `npm run build` (esbuild) ✅
- `npm test` → **126/126 passing** (was 119; +7 resolver tests)

## Notes / decisions
- **`.mcp/server.json` not created.** The canonical MCP-registry manifest is the existing root **`server.json`** (what `mcp-publisher` reads) and it already declares the npm package + stdio transport with an SEO/agent-friendly description. Adding a second copy under `.mcp/` would create a drift risk. Happy to add it if a specific client expects that path.
- `npm run lint` (`tsc --noEmit`) OOM'd in the sandbox under Node 25 — environment, not these changes (esbuild build + full test suite pass). Worth confirming in CI.

## Recommended follow-up
- Release `1.2.4` (bump `server.json` version too) and submit to the MCP registry via `mcp-publisher`.
- Optionally extend the account selector to `imap_test_account` / `imap_disconnect` for full consistency (left out here to keep account-management semantics explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)