### PR TITLE
feat(folders): resolve Sent/Drafts via SPECIAL-USE flags (RFC 6154) + multilingual names

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -769,10 +769,25 @@ export class ImapService {
   }
 
   async appendToSentFolder(accountId: string, rawMessage: Buffer | string): Promise<boolean> {
-    const sentFolderNames = ['Sent Messages', 'Sent', 'INBOX.Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail'];
-    const folder = await this.findFolderByNames(accountId, sentFolderNames);
+    const sentFolderNames = [
+      // English / standard
+      'Sent Messages', 'Sent', 'INBOX.Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail',
+      // French (Outlook / Exchange / Sherweb)
+      'Éléments envoyés', 'Eléments envoyés', 'Messages envoyés',
+      // German
+      'Gesendet', 'Gesendete Elemente', 'Gesendete Objekte',
+      // Spanish
+      'Enviados', 'Elementos enviados',
+      // Portuguese
+      'Enviados', 'Itens Enviados',
+      // Italian
+      'Inviati', 'Posta inviata',
+      // Dutch
+      'Verzonden', 'Verzonden items',
+    ];
+    const folder = await this.findSpecialUseFolder(accountId, '\\Sent', sentFolderNames);
     if (!folder) {
-      console.warn(`[IMAP] No sent folder found for account ${accountId}. Tried: ${sentFolderNames.join(', ')}`);
+      console.warn(`[IMAP] No sent folder found for account ${accountId}. Tried SPECIAL-USE flag \\Sent + names: ${sentFolderNames.join(', ')}`);
       return false;
     }
     return this.appendMessage(accountId, folder, rawMessage, ['\\Seen']);
@@ -783,8 +798,57 @@ export class ImapService {
     return folders.find(f => candidates.includes(f.name))?.name;
   }
 
+  /**
+   * Find a folder by IMAP SPECIAL-USE flag (RFC 6154) first, with fallback
+   * to a list of localized folder names.
+   *
+   * SPECIAL-USE flags (\Sent, \Drafts, \Trash, \Junk, \Archive) are language-
+   * independent and work with any IMAP server that advertises them. This
+   * resolves localized folder names (e.g. "Éléments envoyés" on Sherweb /
+   * Outlook FR) without needing to hardcode every language.
+   *
+   * Fallback to name list keeps backward compatibility with older servers
+   * that don't advertise SPECIAL-USE flags.
+   */
+  async findSpecialUseFolder(
+    accountId: string,
+    specialUseFlag: string,
+    fallbackNames: string[],
+  ): Promise<string | undefined> {
+    const folders = await this.listFolders(accountId);
+
+    // Priority 1: SPECIAL-USE flag match (RFC 6154 — language-independent)
+    const flagMatch = folders.find(f =>
+      Array.isArray(f.attributes) && f.attributes.some(a =>
+        typeof a === 'string' && a.toLowerCase() === specialUseFlag.toLowerCase()
+      )
+    );
+    if (flagMatch) {
+      return flagMatch.name;
+    }
+
+    // Priority 2: name match (fallback for older servers)
+    return folders.find(f => fallbackNames.includes(f.name))?.name;
+  }
+
   async findDraftsFolder(accountId: string): Promise<string | undefined> {
-    return this.findFolderByNames(accountId, ['Drafts', 'Draft', 'INBOX.Drafts', 'INBOX.Draft', '[Gmail]/Drafts']);
+    const draftsFolderNames = [
+      // English
+      'Drafts', 'Draft', 'INBOX.Drafts', 'INBOX.Draft', '[Gmail]/Drafts',
+      // French
+      'Brouillons',
+      // German
+      'Entwürfe',
+      // Spanish
+      'Borradores',
+      // Portuguese
+      'Rascunhos',
+      // Italian
+      'Bozze',
+      // Dutch
+      'Concepten',
+    ];
+    return this.findSpecialUseFolder(accountId, '\\Drafts', draftsFolderNames);
   }
 
   async appendMessage(accountId: string, folder: string, rawMessage: Buffer | string, flags?: string[]): Promise<boolean> {


### PR DESCRIPTION
## Problem

\`appendToSentFolder()\` and \`findDraftsFolder()\` currently hardcode English-only folder names:

\`\`\`ts
const sentFolderNames = ['Sent Messages', 'Sent', 'INBOX.Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail'];
\`\`\`

On IMAP servers using **localized folder names** (e.g. Microsoft Exchange / Outlook / Sherweb hosted in French, German, etc.), these names don't match. The lookup silently returns \`undefined\`, the \`appendMessage\` call is skipped, and the user gets \`savedToSent: false\` — but the tool reports \`success: true\` for the SMTP send. The user thinks the email was sent and saved, but it never appears in their Sent folder via OWA / native Outlook.

**Real-world failure observed:** Sherweb Hosted Exchange (FR-CA) uses \`Éléments envoyés\` / \`Brouillons\`. Every reply silently fails to be archived in the Sent folder.

## Solution

This PR introduces a 2-tier resolution strategy:

1. **Priority 1 — IMAP SPECIAL-USE flags (RFC 6154)**: \`\\Sent\`, \`\\Drafts\`, \`\\Trash\`, \`\\Junk\`, \`\\Archive\` are advertised by the server itself in folder attributes. They are **language-independent** and supported by all modern IMAP servers (Microsoft Exchange/Outlook/Office 365, Dovecot, Cyrus, Gmail, ProtonMail Bridge, etc.).

2. **Priority 2 — localized name fallback**: For older servers that don't advertise SPECIAL-USE, the candidate name list is extended with French, German, Spanish, Portuguese, Italian, and Dutch translations of the system folders.

A new helper \`findSpecialUseFolder(specialUseFlag, fallbackNames)\` encapsulates this logic, and both \`appendToSentFolder()\` and \`findDraftsFolder()\` use it.

## Diff summary

\`src/services/imap-service.ts\`:
- New method \`findSpecialUseFolder()\` (RFC 6154 lookup + name fallback).
- \`appendToSentFolder()\` now uses \`findSpecialUseFolder('\\\\Sent', sentFolderNames)\` with extended multilingual name list.
- \`findDraftsFolder()\` now uses \`findSpecialUseFolder('\\\\Drafts', draftsFolderNames)\` with extended multilingual name list.

## Why SPECIAL-USE first

[RFC 6154](https://datatracker.ietf.org/doc/html/rfc6154) defines these mailbox attributes specifically so that clients don't need to guess folder names by string matching. Any IMAP server respecting modern best practices advertises them via \`LIST\` / \`LSUB\` extended responses.

The existing code already reads \`folder.flags\` in \`listFolders()\` and stores them as \`attributes\` on the \`Folder\` interface — we just need to actually use them.

## Testing

Tested manually with Sherweb Hosted Exchange (FR-CA tenant): \`Éléments envoyés\` is now correctly resolved as the Sent folder via the \`\\Sent\` flag. Reply messages now appear in OWA's "Éléments envoyés" view immediately after send.

No automated tests added for this specific path because the test suite doesn't currently mock IMAP server folder advertisement. Happy to add one if you'd point me at the right pattern.

## Backward compatibility

100% backward compatible:
- Servers that already advertised \`\\Sent\` / \`\\Drafts\` flags: same behavior (folder resolved by flag, name list unused).
- Servers with English folder names: same behavior (folder resolved by name, no SPECIAL-USE advertised or matching).
- Servers with localized folder names but no SPECIAL-USE: **fixed** (folder resolved by extended name list).

## Affected entry points

All three exit points calling \`appendToSentFolder()\` benefit automatically:
- \`imap_send_email\`
- \`imap_reply_to_email\`
- \`imap_forward_email\`

## Out of scope

Other system folders (\`Trash\`, \`Junk\`, \`Archive\`) could benefit from the same treatment but aren't currently used by save-to-folder paths in the codebase. Happy to extend in a follow-up PR if useful.