### PR TITLE
fix(reply-all): exclude account address from To, handle display names

### DIFF
--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -687,12 +687,30 @@ export function emailTools(
 
     // Get original email
     const originalEmail = await imapService.getEmailContent(accountId, folder, uid);
-    
-    // Prepare reply
+
+    // Extract the bare email address from a header value that may include a
+    // display name (e.g. 'Alice <alice@example.com>' → 'alice@example.com').
+    // Returns lowercase for case-insensitive comparison per RFC 5321 §2.4.
+    const extractEmail = (addr: string): string => {
+      const match = addr.match(/<([^>]+)>/);
+      return (match ? match[1] : addr).trim().toLowerCase();
+    };
+
+    // Prepare reply. replyAll: include original To recipients but EXCLUDE
+    // our own address (otherwise the SMTP server delivers a copy back to
+    // our INBOX). Use extracted lowercase address for comparison so it works
+    // when the To header includes display names like 'Us <us@example.com>'.
+    const accountEmail = extractEmail(account.email || account.user);
     const recipients = [originalEmail.from];
     if (replyAll) {
-      const accountEmail = account.email || account.user;
-      recipients.push(...originalEmail.to.filter(addr => addr !== accountEmail));
+      const seen = new Set<string>([accountEmail, ...recipients.map(extractEmail)]);
+      for (const addr of originalEmail.to) {
+        const normalized = extractEmail(addr);
+        if (!seen.has(normalized)) {
+          recipients.push(addr);
+          seen.add(normalized);
+        }
+      }
     }
 
     const emailComposer = {


### PR DESCRIPTION
## Problem

`imap_reply_to_email` with `replyAll: true` keeps the account's own address in the To when the original To header contains a display name. The SMTP server then loops the reply back into the user's INBOX as a `Re:` from themselves.

### Root cause

`src/tools/email-tools.ts:693-696`:

```ts
const recipients = [originalEmail.from];
if (replyAll) {
  const accountEmail = account.email || account.user;
  recipients.push(...originalEmail.to.filter(addr => addr !== accountEmail));
}
```

Compares the To entry (e.g. `'SE.Mauricie <se.mau@scfp1500.org>'`) against the bare email (`'se.mau@scfp1500.org'`) with exact `!==`. The strings are obviously not equal, so the filter is a no-op and our own address survives in To.

### Real-world impact

Reproduced on Sherweb Hosted Exchange (FR-CA tenant). Every Reply All from an Outlook/Exchange thread duplicates into INBOX as `Re: <original subject>` from ourselves, in addition to the (correct) copy archived in Sent.

## Fix

Introduce a small `extractEmail()` helper that:
- Strips display names (`'Name <email>'` → `'email'`).
- Lowercases the result (RFC 5321 §2.4 — local-part is technically case-sensitive but compared case-insensitively by convention; all common providers do this).

Then use a `Set<string>` keyed on extracted addresses to dedup. Seeded with the account address (so we exclude ourselves) and the original sender (already in recipients).

```ts
const extractEmail = (addr: string): string => {
  const match = addr.match(/<([^>]+)>/);
  return (match ? match[1] : addr).trim().toLowerCase();
};

const accountEmail = extractEmail(account.email || account.user);
const recipients = [originalEmail.from];
if (replyAll) {
  const seen = new Set<string>([accountEmail, ...recipients.map(extractEmail)]);
  for (const addr of originalEmail.to) {
    const normalized = extractEmail(addr);
    if (!seen.has(normalized)) {
      recipients.push(addr);
      seen.add(normalized);
    }
  }
}
```

## Backward compatibility

100% backward compatible:
- Bare-email To (no display name) — same behavior, our address is filtered correctly (it was already filtered before).
- Display-name To — **fixed** (our address is now filtered correctly).
- Multiple identical addresses in To — **fixed** as a side effect (deduped).

## Tests

The repo doesn't yet have a unit test fixture for the reply-recipient pipeline (only end-to-end IMAP/SMTP integration). Happy to add a small unit test for `extractEmail()` and a recipients-list assertion if you'd point me at the right harness — I didn't want to drop unrelated test infra in.

## Out of scope (could be a follow-up)

Cc/Bcc are not currently exposed on `EmailMessage` (`src/types/index.ts`). Extending Reply All to also include Cc (after the same self-dedup) would be the natural next step. Happy to do it in a follow-up.

## Companion PR

#83 fixes the related silent `savedToSent: false` failure on non-English locales (Éléments envoyés, Brouillons, etc.). Together they cover the two issues users hit immediately on French/German/etc. Exchange tenants.