### PR TITLE
feat(get-email): return body as Markdown by default (bodyFormat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `imap_get_email` options to control body and text-attachment output (`maxContentLength`, `includeAttachmentText`, `maxAttachmentTextChars`).
 - Text attachment preview fields in email payloads (`attachments[].textContent`, `attachments[].textContentTruncated`).
+- `imap_get_email` `bodyFormat` parameter (`markdown` default, `text`, `html`, `auto`) and a `markdownContent` body field. The body is converted to clean Markdown server-side (Turndown + the GFM strikethrough plugin), with email-specific rules: layout tables flattened, hidden/preheader nodes stripped, `<img>` reduced to its alt text, tracking URLs shortened.
 
 ### Changed
 - `imap_get_email` now reports body truncation via `contentTruncated`.
+- `imap_get_email` returns the body as Markdown by default and omits raw `htmlContent` unless `bodyFormat: "html"` is requested, so large HTML emails (a single marketing mail can be ~119k characters of markup) no longer cross the MCP boundary. `textContent` is still included for backward compatibility.
 - Text extraction only runs for text-like attachments and enforces size limits to avoid binary bloat.
 
 ## [1.1.0] - 2025-12-18

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "open": "^10.2.0",
         "ora": "^8.2.0",
         "pdf-parse": "^1.1.1",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -36,6 +38,7 @@
         "@types/mailparser": "^3.4.6",
         "@types/node": "^24.0.14",
         "@types/pdf-parse": "^1.1.5",
+        "@types/turndown": "^5.0.6",
         "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "^0.27.2",
         "nodemon": "^3.1.10",
@@ -620,6 +623,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -1160,6 +1169,13 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.8",
@@ -4821,6 +4837,25 @@
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
       }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/mailparser": "^3.4.6",
     "@types/node": "^24.0.14",
     "@types/pdf-parse": "^1.1.5",
+    "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.27.2",
     "nodemon": "^3.1.10",
@@ -81,6 +82,8 @@
     "open": "^10.2.0",
     "ora": "^8.2.0",
     "pdf-parse": "^1.1.1",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "zod": "^3.25.76"
   },
   "overrides": {

--- a/src/services/html-to-markdown.ts
+++ b/src/services/html-to-markdown.ts
@@ -1,0 +1,149 @@
+// HTML -> Markdown conversion for email bodies.
+//
+// Why this exists: imap_get_email used to return the raw text/html part, which for a single
+// marketing mail can be ~119k characters of <style>/markup/tracking. That crossed the MCP->LLM
+// boundary and blew the token budget. This module turns the HTML into compact Markdown so the
+// raw HTML never leaves the server.
+//
+// Turndown (+ gfm plugin) does the heavy lifting; the custom rules below tune it for email:
+//   - strip <style>/<script>/<head>/<title>/<noscript>
+//   - drop hidden / preheader nodes (display:none, max-height:0, font-size:0, opacity:0, ...)
+//   - render <img> as its alt text only (e.g. Amazon product names live in alt), drop the image
+//   - shorten tracking URLs and drop empty/mailto-duplicate anchors
+//   - collapse invisible spacer chars and blank-line runs
+//
+// Rule precedence note: Turndown's addRule() *prepends* (so user rules win over the built-in
+// CommonMark rules), but remove() appends to a separate list that is only consulted AFTER the
+// main rule array. A <p style="display:none"> therefore matches the built-in paragraph rule
+// before any remove()-registered filter, so hidden-stripping MUST go through addRule(), not
+// remove(). Verified empirically (turndown 7.2.x).
+
+import TurndownService from 'turndown';
+import gfmPlugin from 'turndown-plugin-gfm';
+
+// Use ONLY the strikethrough plugin, not the full gfm bundle. The gfm `tables` plugin registers
+// a turndownService.keep() for any table without a <th> heading row (lib line ~132), i.e. it
+// emits the raw HTML for that table. Marketing emails are built almost entirely from nested
+// LAYOUT tables (no heading row), so the full gfm bundle would leak raw HTML for the typical
+// email. We instead flatten tables to plain blocks (see the table rules below).
+const { strikethrough } = gfmPlugin;
+
+// zero-width / invisible / formatting chars used as preheader spacers in marketing mail
+// (mirrors _INVISIBLE in _Tools/scripts/mail-body-clean.py; incl. U+00AD soft hyphen, U+034F).
+// Written as ASCII \u escapes on purpose: some of these (e.g. U+2028) are line terminators and
+// would break a regex literal written with the raw characters.
+const INVISIBLE_CODE_POINTS = [
+  0x00ad, 0x034f, 0x061c, 0x115f, 0x1160, 0x17b4, 0x17b5, 0x180e,
+  0x200b, 0x200c, 0x200d, 0x200e, 0x200f, 0x2028, 0x2029,
+  0x202a, 0x202b, 0x202c, 0x202d, 0x202e,
+  0x2060, 0x2061, 0x2062, 0x2063, 0x2064,
+  0x2066, 0x2067, 0x2068, 0x2069, 0x206a, 0x206b, 0x206c, 0x206d, 0x206e, 0x206f,
+  0xfeff,
+];
+const INVISIBLE = new RegExp(
+  '[' + INVISIBLE_CODE_POINTS.map((c) => '\\u' + c.toString(16).padStart(4, '0')).join('') + ']',
+  'g',
+);
+const NBSP = /\u00a0/g;
+
+function isHidden(node: any): boolean {
+  if (!node || typeof node.getAttribute !== 'function') return false;
+  const style = (node.getAttribute('style') || '').replace(/\s+/g, '').toLowerCase();
+  if (!style) return false;
+  return /display:none|visibility:hidden|(?:max-height|font-size|line-height|opacity):0(?![.\d])/.test(style);
+}
+
+function buildService(): TurndownService {
+  const td = new TurndownService({
+    headingStyle: 'atx',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+    emDelimiter: '*',
+  });
+
+  td.use(strikethrough);
+
+  // Tags whose content is never readable body text.
+  td.remove(['style', 'script', 'head', 'title', 'noscript']);
+
+  // Flatten tables to plain blocks. Email tables are overwhelmingly layout scaffolding; rendering
+  // them as a GFM grid is noise, and (see import note) the gfm tables plugin would keep them as
+  // raw HTML. table/thead/tbody/tfoot/tr are transparent (emit their content); each cell becomes
+  // its own block so cell text never glues together. addRule prepends, so these win over both the
+  // built-in handling and any plugin rule.
+  td.addRule('flattenTableContainers', {
+    filter: ['table', 'thead', 'tbody', 'tfoot', 'tr', 'colgroup', 'col', 'caption'],
+    replacement: (content: string) => content,
+  });
+  td.addRule('flattenTableCell', {
+    filter: ['th', 'td'],
+    replacement: (content: string) => {
+      const t = content.trim();
+      return t ? t + '\n\n' : '';
+    },
+  });
+
+  // Hidden / preheader subtrees. Must be addRule (prepends -> precedence) so it preempts the
+  // built-in paragraph/div handling. replacement returns '' to discard the rendered subtree.
+  td.addRule('stripHidden', {
+    filter: (node: any) => isHidden(node),
+    replacement: () => '',
+  });
+
+  // Images: keep only the alt text (product names, captions); drop the <img> itself.
+  td.addRule('imgAlt', {
+    filter: 'img',
+    replacement: (_content: string, node: any) => {
+      const alt = (node.getAttribute('alt') || '').trim();
+      return alt || '';
+    },
+  });
+
+  // Links: shorten tracking URLs, drop empty/mailto-duplicate anchors.
+  td.addRule('shortLink', {
+    filter: (node: any) => node.nodeName === 'A' && !!node.getAttribute('href'),
+    replacement: (content: string, node: any) => {
+      const text = content.trim();
+      if (!text) return '';
+      let href = (node.getAttribute('href') || '').trim();
+      if (!href || href.startsWith('mailto:')) return text;
+      if (href.length > 100) href = href.split(/[?#]/)[0]; // drop query/fragment (almost always tracking)
+      if (!href || href === text) return text;
+      return `[${text}](${href})`;
+    },
+  });
+
+  return td;
+}
+
+// Module singleton: rules are static, the service is stateless across conversions.
+const service = buildService();
+
+/**
+ * Convert an HTML email body to compact Markdown.
+ * Returns '' for empty/whitespace-only input. Never throws on conversion failure: on error it
+ * falls back to a crude tag-strip so the caller always gets readable text.
+ */
+export function htmlToMarkdown(html: string | null | undefined): string {
+  if (!html || !html.trim()) return '';
+  let md: string;
+  try {
+    md = service.turndown(html);
+  } catch {
+    // Defensive fallback: strip tags so a converter bug never blanks the body entirely.
+    md = html.replace(/<[^>]+>/g, ' ');
+  }
+  return normalizeWhitespace(md);
+}
+
+/** Collapse invisible spacer chars, NBSP, and excess blank lines; trim each line. */
+export function normalizeWhitespace(text: string): string {
+  let t = text.replace(INVISIBLE, '').replace(NBSP, ' ');
+  t = t.replace(/[ \t]+\n/g, '\n');
+  t = t.replace(/\n{3,}/g, '\n\n');
+  t = t
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/g, ''))
+    .join('\n');
+  return t.trim();
+}

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1,7 +1,8 @@
 import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
-import { ImapAccount, EmailMessage, EmailContent, Folder, SearchCriteria } from '../types/index.js';
+import { ImapAccount, EmailMessage, EmailContent, EmailBodyFormat, Folder, SearchCriteria } from '../types/index.js';
 import type { AccountManager } from './account-manager.js';
+import { htmlToMarkdown, normalizeWhitespace } from './html-to-markdown.js';
 
 /**
  * Providers that require IMAP access to be manually enabled in account settings.
@@ -92,6 +93,12 @@ interface EmailContentOptions {
   includeAttachmentText?: boolean;
   maxAttachmentTextBytes?: number;
   maxAttachmentTextChars?: number;
+  // Controls how the body is returned. 'markdown' (default) returns markdownContent and omits
+  // raw htmlContent so HTML never crosses the MCP boundary; 'html' keeps the legacy raw HTML;
+  // 'text' returns plain text only; 'auto' prefers a substantive text/plain part, else markdown.
+  bodyFormat?: EmailBodyFormat;
+  // Minimum length of a text/plain part to treat it as the substantive body (markdown/auto).
+  markdownThreshold?: number;
 }
 
 export class ImapService {
@@ -375,7 +382,37 @@ export class ImapService {
         includeAttachmentText = false,
         maxAttachmentTextBytes = 256 * 1024,
         maxAttachmentTextChars = 100000,
+        bodyFormat = 'markdown',
+        markdownThreshold = 200,
       } = options;
+
+      // Body assembly per bodyFormat. The point is that raw HTML never crosses the boundary
+      // unless explicitly requested via bodyFormat: 'html'.
+      const rawText = parsed.text || undefined;
+      const rawHtml = parsed.html || undefined;
+      let textContent: string | undefined;
+      let htmlContent: string | undefined;
+      let markdownContent: string | undefined;
+
+      if (bodyFormat === 'html') {
+        textContent = rawText;
+        htmlContent = rawHtml;
+      } else if (bodyFormat === 'text') {
+        // Plain text if present, else a tag-stripped/normalized rendering of the HTML.
+        textContent = rawText ? normalizeWhitespace(rawText) : (rawHtml ? htmlToMarkdown(rawHtml) : undefined);
+      } else {
+        // 'markdown' (default) and 'auto': prefer a substantive text/plain part, else convert HTML.
+        const cleanText = rawText ? normalizeWhitespace(rawText) : '';
+        if (cleanText.length >= markdownThreshold) {
+          markdownContent = cleanText;
+        } else if (rawHtml) {
+          markdownContent = htmlToMarkdown(rawHtml);
+        } else {
+          markdownContent = cleanText || undefined;
+        }
+        // Keep textContent for backward compatibility with consumers that still read it.
+        textContent = rawText;
+      }
       const textAttachmentExtensions = ['.txt', '.md', '.markdown', '.csv', '.log', '.json', '.xml', '.yml', '.yaml'];
       const pdfExtensions = ['.pdf'];
 
@@ -412,8 +449,10 @@ export class ImapService {
         inReplyTo: parsed.inReplyTo as string | undefined,
         flags: Array.from(source.flags || []),
         headers,
-        textContent: parsed.text,
-        htmlContent: parsed.html || undefined,
+        textContent,
+        htmlContent,
+        markdownContent,
+        bodyFormat,
         attachments: await Promise.all((parsed.attachments || []).map(async (att: any) => {
           const filename = att.filename || 'unknown';
           const contentType = att.contentType || 'application/octet-stream';

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -90,29 +90,34 @@ export function emailTools(
   });
 
   // Get email content tool
+  // @ts-expect-error TS2589: MCP SDK registerTool + zod v3 exceed TS's type instantiation depth. Runtime schema validation is unaffected.
   server.registerTool('imap_get_email', {
-    description: 'Read the FULL content of a single email by its UID (plain text + HTML body, sender/recipients, date, attachment list, optional raw headers and text-attachment previews). Use after imap_search_emails or imap_get_latest_emails gives you a uid. Body text is truncated to maxContentLength to protect the context window — raise it for long messages. To fetch attachment bytes, use imap_download_attachment.',
+    description: 'Read the FULL content of a single email by its UID (body, sender/recipients, date, attachment list, optional raw headers and text-attachment previews). By default the body is returned as clean Markdown in markdownContent and raw HTML is omitted so it never crosses the boundary; set bodyFormat to "html" for the legacy raw htmlContent, or "text" for plain text only. Use after imap_search_emails or imap_get_latest_emails gives you a uid. Body text is truncated to maxContentLength to protect the context window — raise it for long messages. To fetch attachment bytes, use imap_download_attachment.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       uid: z.coerce.number().describe('Email UID'),
-      maxContentLength: z.coerce.number().default(10000).describe('Maximum characters to return for text and HTML body content'),
+      maxContentLength: z.coerce.number().default(10000).describe('Maximum characters to return for each body field (text/markdown/html)'),
+      bodyFormat: z.enum(['markdown', 'text', 'html', 'auto']).default('markdown').describe('How to return the body. "markdown" (default): clean Markdown via Turndown in markdownContent, raw htmlContent omitted so HTML never crosses the boundary. "text": plain text only in textContent. "html": legacy raw htmlContent. "auto": substantive text/plain if available, else Markdown.'),
       includeAttachmentText: z.boolean().default(true).describe('Include text attachment previews when available'),
       maxAttachmentTextChars: z.coerce.number().default(100000).describe('Maximum characters to return per text attachment'),
       includeHeaders: z.boolean().default(false).describe('Include raw email headers (e.g. List-Unsubscribe, List-Unsubscribe-Post)'),
     }
-  }, async ({ accountId: rawAccountId, accountName, folder, uid, maxContentLength, includeAttachmentText, maxAttachmentTextChars, includeHeaders }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, maxContentLength, bodyFormat, includeAttachmentText, maxAttachmentTextChars, includeHeaders }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const email = await imapService.getEmailContent(accountId, folder, uid, {
       includeAttachmentText,
       maxAttachmentTextChars,
+      bodyFormat,
     });
+    const cap = (s?: string) => (s === undefined ? undefined : s.substring(0, maxContentLength));
     const textTruncated = email.textContent ? email.textContent.length > maxContentLength : false;
     const htmlTruncated = email.htmlContent ? email.htmlContent.length > maxContentLength : false;
-    const contentTruncated = (textTruncated || htmlTruncated)
-      ? { text: textTruncated || undefined, html: htmlTruncated || undefined }
+    const markdownTruncated = email.markdownContent ? email.markdownContent.length > maxContentLength : false;
+    const contentTruncated = (textTruncated || htmlTruncated || markdownTruncated)
+      ? { text: textTruncated || undefined, html: htmlTruncated || undefined, markdown: markdownTruncated || undefined }
       : undefined;
-    
+
     const { headers: rawHeaders, ...emailWithoutHeaders } = email;
 
     return {
@@ -121,8 +126,9 @@ export function emailTools(
         text: JSON.stringify({
           email: {
             ...emailWithoutHeaders,
-            textContent: email.textContent?.substring(0, maxContentLength),
-            htmlContent: email.htmlContent?.substring(0, maxContentLength),
+            textContent: cap(email.textContent),
+            htmlContent: cap(email.htmlContent),
+            markdownContent: cap(email.markdownContent),
             contentTruncated,
             ...(includeHeaders ? { headers: rawHeaders } : {}),
           },
@@ -694,8 +700,8 @@ export function emailTools(
       throw new Error(`Account ${accountId} not found`);
     }
 
-    // Get original email
-    const originalEmail = await imapService.getEmailContent(accountId, folder, uid);
+    // Get original email (envelope only is needed here; skip body conversion)
+    const originalEmail = await imapService.getEmailContent(accountId, folder, uid, { bodyFormat: 'text' });
 
     // Extract the bare email address from a header value that may include a
     // display name (e.g. 'Alice <alice@example.com>' → 'alice@example.com').
@@ -775,9 +781,9 @@ export function emailTools(
       throw new Error(`Account ${accountId} not found`);
     }
 
-    // Get original email
-    const originalEmail = await imapService.getEmailContent(accountId, folder, uid);
-    
+    // Get original email (needs both plain text and raw HTML to reconstruct the forward)
+    const originalEmail = await imapService.getEmailContent(accountId, folder, uid, { bodyFormat: 'html' });
+
     // Prepare forwarded content
     const forwardHeader = `\n\n---------- Forwarded message ----------\nFrom: ${originalEmail.from}\nDate: ${originalEmail.date.toLocaleString()}\nSubject: ${originalEmail.subject}\nTo: ${originalEmail.to.join(', ')}\n\n`;
     

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,9 +38,13 @@ export interface EmailMessage {
   flags: string[];
 }
 
+export type EmailBodyFormat = 'markdown' | 'text' | 'html' | 'auto';
+
 export interface EmailContent extends EmailMessage {
   textContent?: string;
   htmlContent?: string;
+  markdownContent?: string;
+  bodyFormat?: EmailBodyFormat;
   headers: Record<string, string | string[]>;
   attachments: Attachment[];
 }

--- a/src/types/turndown-plugin-gfm.d.ts
+++ b/src/types/turndown-plugin-gfm.d.ts
@@ -1,0 +1,13 @@
+// turndown-plugin-gfm ships no type declarations and @types/turndown covers only
+// the core package, so under noImplicitAny the bare import is an error (TS7016).
+// Declare the plugin's named + default exports with turndown's own Plugin type.
+declare module 'turndown-plugin-gfm' {
+  import type TurndownService from 'turndown';
+  type Plugin = TurndownService.Plugin;
+  export const gfm: Plugin;
+  export const tables: Plugin;
+  export const strikethrough: Plugin;
+  export const taskListItems: Plugin;
+  const plugins: { gfm: Plugin; tables: Plugin; strikethrough: Plugin; taskListItems: Plugin };
+  export default plugins;
+}

--- a/tests/html-to-markdown.test.ts
+++ b/tests/html-to-markdown.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToMarkdown, normalizeWhitespace } from '../src/services/html-to-markdown.js';
+
+describe('htmlToMarkdown', () => {
+  it('returns empty string for empty/whitespace input', () => {
+    expect(htmlToMarkdown('')).toBe('');
+    expect(htmlToMarkdown('   \n  ')).toBe('');
+    expect(htmlToMarkdown(null)).toBe('');
+    expect(htmlToMarkdown(undefined)).toBe('');
+  });
+
+  it('flattens layout/data tables to readable cell text without leaking raw HTML', () => {
+    // Email tables (incl. heading-less layout tables) must NOT come back as raw <table> HTML.
+    const html = `
+      <table>
+        <thead><tr><th>Artikel</th><th>Menge</th></tr></thead>
+        <tbody><tr><td>Chain Wax</td><td>1</td></tr></tbody>
+      </table>
+      <table><tr><td><p>Layout cell A</p></td><td><p>Layout cell B</p></td></tr></table>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Artikel');
+    expect(md).toContain('Chain Wax');
+    expect(md).toContain('Layout cell A');
+    expect(md).toContain('Layout cell B');
+    expect(md).not.toMatch(/<\/?table/i);
+    expect(md).not.toMatch(/<\/?t[rdh]/i);
+  });
+
+  it('strips hidden / preheader nodes (display:none, max-height:0, font-size:0, opacity:0)', () => {
+    const html = `
+      <p style="display:none">HIDDEN PREHEADER</p>
+      <div style="max-height:0px">collapsed</div>
+      <span style="font-size:0">zero font</span>
+      <p style="opacity:0">invisible</p>
+      <p>Visible body</p>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('Visible body');
+    expect(md).not.toContain('HIDDEN PREHEADER');
+    expect(md).not.toContain('collapsed');
+    expect(md).not.toContain('zero font');
+    expect(md).not.toContain('invisible');
+  });
+
+  it('keeps img alt text (where product names live) and drops the image itself', () => {
+    const md = htmlToMarkdown('<img alt="Fitgadgets Chain Wax" src="https://track.example/pixel.gif">');
+    expect(md).toContain('Fitgadgets Chain Wax');
+    expect(md).not.toContain('pixel.gif');
+    expect(md).not.toContain('![');
+  });
+
+  it('drops images with no alt (tracking pixels)', () => {
+    const md = htmlToMarkdown('<p>Body</p><img src="https://track.example/p.gif" width="1" height="1">');
+    expect(md.trim()).toBe('Body');
+  });
+
+  it('shortens long tracking URLs to the path before the query', () => {
+    const longUrl = 'https://example.com/path?utm_source=' + 'x'.repeat(120);
+    const md = htmlToMarkdown(`<a href="${longUrl}">Order details</a>`);
+    expect(md).toContain('[Order details](https://example.com/path)');
+    expect(md).not.toContain('utm_source');
+  });
+
+  it('keeps short links inline and renders mailto as plain text', () => {
+    expect(htmlToMarkdown('<a href="https://ame3.ai/x">link</a>')).toContain('[link](https://ame3.ai/x)');
+    const mailto = htmlToMarkdown('<a href="mailto:peter@example.com">Peter</a>');
+    expect(mailto).toBe('Peter');
+  });
+
+  it('removes <style>/<script> content entirely and emits no raw HTML tags', () => {
+    const html = `<style>.x{color:red}</style><script>track()</script><h1>Heading</h1><p>Para</p>`;
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('# Heading');
+    expect(md).toContain('Para');
+    expect(md).not.toContain('color:red');
+    expect(md).not.toContain('track()');
+    expect(md).not.toMatch(/<[a-z][^>]*>/i);
+  });
+
+  it('collapses invisible spacer chars and excess blank lines', () => {
+    const out = normalizeWhitespace('a­​‌\n\n\n\nb c   \n');
+    expect(out).toBe('a\n\nb c');
+  });
+});

--- a/tests/imap-service.test.ts
+++ b/tests/imap-service.test.ts
@@ -711,7 +711,7 @@ describe('ImapService', () => {
       expect(result.headers).toEqual({});
     });
 
-    it('should preserve existing fields unchanged', async () => {
+    it('preserves envelope fields and returns Markdown by default (raw HTML omitted)', async () => {
       mockInstance.fetchOneMock.mockResolvedValue({
         source: Buffer.from('fake raw email'),
         flags: new Set(['\\Seen']),
@@ -734,9 +734,40 @@ describe('ImapService', () => {
 
       expect(result.from).toBe('sender@test.com');
       expect(result.subject).toBe('Backward compat');
+      expect(result.uid).toBe(5);
+      // Default bodyFormat is 'markdown': the short text/plain part is below threshold, so the
+      // body is converted from HTML; raw htmlContent must NOT cross the boundary.
+      expect(result.bodyFormat).toBe('markdown');
+      expect(result.textContent).toBe('Plain text');
+      expect(result.markdownContent).toBe('**HTML**');
+      expect(result.htmlContent).toBeUndefined();
+    });
+
+    it('returns raw htmlContent only when bodyFormat is "html"', async () => {
+      mockInstance.fetchOneMock.mockResolvedValue({
+        source: Buffer.from('fake raw email'),
+        flags: new Set(['\\Seen']),
+      });
+
+      mockedSimpleParser.mockResolvedValue({
+        date: new Date('2025-06-01'),
+        from: { text: 'sender@test.com' },
+        to: [{ text: 'recipient@test.com' }],
+        subject: 'Legacy HTML',
+        messageId: '<legacy@test.com>',
+        text: 'Plain text',
+        html: '<b>HTML</b>',
+        headers: new Map(),
+        attachments: [],
+      } as any);
+
+      await imapService.connect(mockAccount);
+      const result = await imapService.getEmailContent(mockAccount.id, 'INBOX', 6, { bodyFormat: 'html' });
+
+      expect(result.bodyFormat).toBe('html');
       expect(result.textContent).toBe('Plain text');
       expect(result.htmlContent).toBe('<b>HTML</b>');
-      expect(result.uid).toBe(5);
+      expect(result.markdownContent).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

`imap_get_email` previously returned the raw `text/html` part. A single marketing email can be ~119k characters of HTML, markup and tracking, which crosses the MCP boundary and blows the model's token budget. This PR converts the body to clean Markdown **server-side** so the raw HTML never leaves the server.

## What changed

New `bodyFormat` parameter on `imap_get_email` (default `markdown`):

| value | behaviour |
|---|---|
| `markdown` (default) | clean Markdown in `markdownContent`; raw `htmlContent` **omitted** |
| `auto` | substantive `text/plain` if present, else Markdown |
| `html` | legacy raw `htmlContent` (unchanged) |
| `text` | plain text only |

Conversion (new `src/services/html-to-markdown.ts`) uses Turndown + the GFM **strikethrough** plugin, with email-specific rules:
- layout tables flattened to readable text (the GFM *tables* plugin `keep()`s heading-less tables as raw HTML, which is exactly what marketing email is built from),
- hidden / preheader nodes stripped (`display:none`, `max-height:0`, `font-size:0`, `opacity:0`, …),
- `<img>` reduced to its `alt` text (where product names live); tracking pixels dropped,
- long tracking URLs shortened to the path before the query.

`textContent` is still returned, so existing consumers keep working. `imap_reply_to_email` and `imap_forward_email` request the body format they need internally (`text` / `html`).

## Backwards compatibility

The only behaviour change is the new default: `markdownContent` is populated and raw `htmlContent` is omitted unless `bodyFormat: "html"` is passed. Anyone who needs the raw HTML can opt back in with a single argument.

## Tests / CI

- New `tests/html-to-markdown.test.ts` (table flattening, hidden-strip, img-alt, tracking-pixel drop, URL shortening, …); `tests/imap-service.test.ts` updated for the new default contract.
- Green locally on all four CI gates: **142 tests pass**, `tsc --noEmit --skipLibCheck` clean, `npm run build` emits `dist/index.js` / `dist/setup.js` / `dist/web/server.js`, and `npm audit --audit-level=high` reports **0 vulnerabilities**.
- Verified live against Apple-hosted IMAP and Gmail: HTML-heavy marketing mail → compact Markdown; `bodyFormat:"html"` still returns the raw body.

## Notes

- Adds `turndown` + `turndown-plugin-gfm` runtime deps and `@types/turndown` (dev), plus a small ambient `.d.ts` for `turndown-plugin-gfm` (it ships no types).
- `imap_get_email`'s `registerTool` now carries the same `@ts-expect-error TS2589` annotation the other tools already use; the added enum field tips zod v3 + the SDK over TS's instantiation-depth limit (runtime validation is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
