### PR TITLE
fix(reconnect): rebuild a fresh ImapFlow instead of reusing the closed instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `imap_get_email` now reports body truncation via `contentTruncated`.
 - Text extraction only runs for text-like attachments and enforces size limits to avoid binary bloat.
 
+### Fixed
+- Reconnect after an idle connection drop no longer fails with `Can not re-use ImapFlow instance`. ImapFlow instances are single-use, so `ImapService.ensureConnected` now tears down the dead client and constructs a fresh `ImapFlow` (via `connect()`) instead of calling `.connect()` on the stale object. This affected every multi-step IMAP workflow where the socket idled out between two tool calls (e.g. an `imap_connect` followed minutes later by an `imap_move_email`). Regression test: `tests/imap-service-reconnect.test.ts`.
+
 ## [1.1.0] - 2025-12-18
 
 ### Security

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -182,7 +182,11 @@ export class ImapService {
     }
 
     if (!state.isConnected || !state.client.usable) {
-      // Try to reconnect
+      // Try to reconnect. ImapFlow instances are single-use: once a client has
+      // connected and then closed (e.g. an idle-timeout between two tool calls),
+      // calling .connect() on the SAME object throws "Can not re-use ImapFlow
+      // instance". So tear the dead client down and build a fresh one via
+      // connect(), instead of reusing state.client.
       const attempts = this.reconnectAttempts.get(accountId) || 0;
       if (attempts >= this.maxReconnectAttempts) {
         throw new Error(`Failed to reconnect to account ${accountId} after ${this.maxReconnectAttempts} attempts`);
@@ -191,13 +195,26 @@ export class ImapService {
       this.reconnectAttempts.set(accountId, attempts + 1);
       console.log(`Reconnecting to account ${accountId} (attempt ${attempts + 1})`);
 
+      const account = state.account;
       try {
-        await state.client.connect();
-        state.isConnected = true;
-        this.reconnectAttempts.set(accountId, 0);
+        // Dispose the unusable instance; the connection is already gone, so
+        // ignore any teardown error.
+        try {
+          await state.client.logout();
+        } catch {
+          // ignore
+        }
+        this.connections.delete(accountId);
+
+        // Build a brand-new ImapFlow client + connection state. connect() resets
+        // the reconnect-attempt counter to 0 on success.
+        await this.connect(account);
+        state = this.connections.get(accountId);
+        if (!state) {
+          throw new Error('connection state missing after reconnect');
+        }
       } catch (err) {
-        state.isConnected = false;
-        throw new Error(`Failed to reconnect: ${enrichConnectionError(err, state.account.host)}`);
+        throw new Error(`Failed to reconnect: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
 

--- a/tests/imap-service-reconnect.test.ts
+++ b/tests/imap-service-reconnect.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ImapService } from '../src/services/imap-service.js';
+import { ImapAccount } from '../src/types/index.js';
+
+// Every ImapFlow the service constructs is recorded here so a test can assert
+// that a reconnect builds a FRESH instance instead of reusing a dead one.
+const instances: any[] = [];
+
+// A mock that mimics the one ImapFlow invariant that caused the production bug:
+// an instance is single-use. Once it has connected, calling .connect() on the
+// SAME object again rejects with "Can not re-use ImapFlow instance" (the real
+// imapflow error). The service must therefore construct a new instance.
+vi.mock('imapflow', () => {
+  return {
+    ImapFlow: class {
+      usable = true;
+      connectedOnce = false;
+      connectMock = vi.fn().mockResolvedValue(undefined);
+      logoutMock = vi.fn().mockResolvedValue(undefined);
+      listMock = vi.fn().mockResolvedValue([
+        { path: 'INBOX', delimiter: '/', flags: [] },
+      ]);
+      constructor() {
+        instances.push(this);
+      }
+      connect() {
+        if (this.connectedOnce) {
+          return Promise.reject(new Error('Can not re-use ImapFlow instance'));
+        }
+        this.connectedOnce = true;
+        return this.connectMock();
+      }
+      logout() { return this.logoutMock(); }
+      list() { return this.listMock(); }
+      on() { /* no-op */ }
+    },
+  };
+});
+
+describe('ImapService reconnect (ImapFlow instances are single-use)', () => {
+  let imapService: ImapService;
+  let account: ImapAccount;
+
+  beforeEach(() => {
+    instances.length = 0;
+    imapService = new ImapService();
+    account = {
+      id: 'acc',
+      name: 'Test',
+      host: 'imap.test.com',
+      port: 993,
+      user: 'user@test.com',
+      password: 'pw',
+      tls: true,
+    };
+  });
+
+  it('rebuilds a fresh ImapFlow when the live connection went stale', async () => {
+    await imapService.connect(account);
+    expect(instances).toHaveLength(1);
+
+    // Simulate an idle-timeout drop between two tool calls: the client object is
+    // still cached but no longer usable.
+    instances[0].usable = false;
+
+    // The next operation must transparently reconnect. With the old code this
+    // called .connect() on the dead instance and threw
+    // "Failed to reconnect: Can not re-use ImapFlow instance".
+    const folders = await imapService.listFolders(account.id);
+
+    expect(folders).toHaveLength(1);
+    // A brand-new instance was constructed and used (not the dead one reused).
+    expect(instances).toHaveLength(2);
+    expect(instances[1].usable).toBe(true);
+    expect(instances[1].connectedOnce).toBe(true);
+  });
+
+  it('does not throw the "Can not re-use ImapFlow instance" error on reconnect', async () => {
+    await imapService.connect(account);
+    instances[0].usable = false;
+
+    await expect(imapService.listFolders(account.id)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

`ImapService.ensureConnected()` tried to recover a dropped connection by calling `.connect()` again on the **same** `ImapFlow` instance. ImapFlow instances are single-use, so that throws `Can not re-use ImapFlow instance`, and every multi-step workflow that idled out between two tool calls failed mid-run (e.g. an `imap_connect` followed minutes later by an `imap_move_email` / `imap_search_emails`), forcing a manual reconnect.

## Fix

On the reconnect path, tear the dead client down (best-effort `logout()`, drop the cached connection state) and build a **fresh** `ImapFlow` via `connect()` instead of reusing the stale object. The bulk-delete chunk loop relies on the same `ensureConnected()`, so the one fix covers it too.

## Tests / CI

- New regression test `tests/imap-service-reconnect.test.ts`: a mock `ImapFlow` that rejects a second `.connect()` on the same instance, asserting the service builds a new client.
- Green locally on all four CI gates: **134 tests pass**, `tsc --noEmit --skipLibCheck` clean, `npm run build` emits `dist/index.js` / `dist/setup.js` / `dist/web/server.js`, and `npm audit --audit-level=high` reports **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
