### PR TITLE
feat: add imap_find_email_by_message_id (Message-ID -> {folder, uid})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `imap_find_email_by_message_id` tool — resolve a stable RFC822 Message-ID to its current `{folder, uid}` across folders, robust to the message having been moved/archived (IMAP UIDs are folder-relative). Gmail `\All` fast path; generic INBOX → `\Archive` → `\Sent` → remaining folders. Exact-match verification against `envelope.messageId` rejects HEADER substring false-positives. Returns basic envelope + `foldersSearched` diagnostic.
+- `messageId` search criterion on `imap_search_emails` (maps to IMAP `HEADER MESSAGE-ID`, substring-matched).
 - `imap_get_email` options to control body and text-attachment output (`maxContentLength`, `includeAttachmentText`, `maxAttachmentTextChars`).
 - Text attachment preview fields in email payloads (`attachments[].textContent`, `attachments[].textContentTruncated`).
 

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1,6 +1,6 @@
 import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
-import { ImapAccount, EmailMessage, EmailContent, Folder, SearchCriteria } from '../types/index.js';
+import { ImapAccount, EmailMessage, EmailContent, Folder, SearchCriteria, EmailLocation } from '../types/index.js';
 import type { AccountManager } from './account-manager.js';
 
 /**
@@ -1011,6 +1011,12 @@ export class ImapService {
     if (criteria.draft !== undefined) {
       query.draft = criteria.draft;
     }
+    if (criteria.messageId) {
+      // Apple-hosted IMAP only matches the FULL bracketed Message-ID; Gmail
+      // accepts either. Send the bracketed form (works on both); callers verify
+      // exact equality against the fetched envelope.messageId afterwards.
+      query.header = { 'message-id': this.bracketMessageId(criteria.messageId) };
+    }
 
     // If no criteria, search all
     if (Object.keys(query).length === 0) {
@@ -1018,5 +1024,108 @@ export class ImapService {
     }
 
     return query;
+  }
+
+  private normalizeMessageId(id: string | undefined | null): string {
+    if (!id) return '';
+    return id.trim().replace(/^<+/, '').replace(/>+$/, '').trim().toLowerCase();
+  }
+
+  /** Full bracketed Message-ID for IMAP HEADER search (case preserved). */
+  private bracketMessageId(id: string | undefined | null): string {
+    const bare = String(id || '').trim().replace(/^<+/, '').replace(/>+$/, '').trim();
+    return bare ? `<${bare}>` : '';
+  }
+
+  private flattenFolders(folders: Folder[]): Folder[] {
+    const out: Folder[] = [];
+    for (const f of folders) {
+      out.push(f);
+      if (f.children?.length) out.push(...this.flattenFolders(f.children));
+    }
+    return out;
+  }
+
+  /**
+   * Folder search order for findEmailByMessageId. Gmail: the \All mailbox
+   * ([Gmail]/All Mail) holds every message regardless of label, so it alone
+   * finds archived/moved mail (\All excludes Trash/Spam, included explicitly).
+   * Generic IMAP: INBOX → \Archive → \Sent → remaining selectable folders.
+   */
+  private async resolveFolderSearchOrder(accountId: string): Promise<string[]> {
+    const flat = this.flattenFolders(await this.listFolders(accountId));
+    const hasFlag = (f: Folder, flag: string) =>
+      (f.attributes || []).some(a => a.toLowerCase() === flag.toLowerCase());
+
+    const allMail = flat.find(f => hasFlag(f, '\\All'));
+    if (allMail) {
+      return [
+        allMail.name,
+        flat.find(f => hasFlag(f, '\\Trash'))?.name,
+        flat.find(f => hasFlag(f, '\\Junk'))?.name,
+      ].filter(Boolean) as string[];
+    }
+
+    const order: string[] = [];
+    const pushOnce = (name?: string) => {
+      if (name && !order.includes(name)) order.push(name);
+    };
+    pushOnce(flat.find(f => f.name.toUpperCase() === 'INBOX')?.name);
+    pushOnce(flat.find(f => hasFlag(f, '\\Archive'))?.name);
+    pushOnce(flat.find(f => hasFlag(f, '\\Sent'))?.name);
+    for (const f of flat) {
+      if (hasFlag(f, '\\Noselect')) continue;
+      pushOnce(f.name);
+    }
+    return order;
+  }
+
+  /**
+   * Locate a message by its RFC822 Message-ID across folders and return its
+   * current { folder, uid }. Robust to the message having been moved/archived
+   * (IMAP UIDs are folder-relative). Returns found:false if nowhere located.
+   */
+  async findEmailByMessageId(
+    accountId: string,
+    messageId: string,
+    folders?: string[],
+  ): Promise<EmailLocation> {
+    const target = this.normalizeMessageId(messageId);
+    if (!target) return { found: false, foldersSearched: [] };
+
+    const MAX_FOLDERS = 25;
+    const order = (folders && folders.length > 0
+      ? folders
+      : await this.resolveFolderSearchOrder(accountId)
+    ).slice(0, MAX_FOLDERS);
+
+    const foldersSearched: string[] = [];
+    for (const folder of order) {
+      foldersSearched.push(folder);
+      let candidates: EmailMessage[];
+      try {
+        candidates = await this.searchEmails(accountId, folder, { messageId });
+      } catch {
+        // Unselectable (\Noselect) or vanished folder — skip.
+        continue;
+      }
+      for (const msg of candidates) {
+        // HEADER search is substring-matched; reject false-positives.
+        if (this.normalizeMessageId(msg.messageId) === target) {
+          return {
+            found: true,
+            folder,
+            uid: msg.uid,
+            messageId: msg.messageId,
+            subject: msg.subject,
+            from: msg.from,
+            date: msg.date,
+            flags: msg.flags,
+            foldersSearched,
+          };
+        }
+      }
+    }
+    return { found: false, foldersSearched };
   }
 }

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -59,6 +59,7 @@ export function emailTools(
       before: z.string().optional().describe('Search emails before date (YYYY-MM-DD)'),
       seen: z.boolean().optional().describe('Filter by read/unread status'),
       flagged: z.boolean().optional().describe('Filter by flagged status'),
+      messageId: z.string().optional().describe('Search by RFC822 Message-ID header (substring match)'),
       limit: z.coerce.number().optional().default(50).describe('Maximum number of results'),
     }
   }, async ({ accountId: rawAccountId, accountName, folder, limit, ...searchCriteria }) => {
@@ -73,7 +74,8 @@ export function emailTools(
     if (searchCriteria.before) criteria.before = parseDateOnly(searchCriteria.before);
     if (searchCriteria.seen !== undefined) criteria.seen = searchCriteria.seen;
     if (searchCriteria.flagged !== undefined) criteria.flagged = searchCriteria.flagged;
-    
+    if (searchCriteria.messageId) criteria.messageId = searchCriteria.messageId;
+
     const messages = await imapService.searchEmails(accountId, folder, criteria);
     const limitedMessages = messages.slice(0, limit);
     
@@ -856,5 +858,27 @@ export function emailTools(
         }]
       };
     }
+  });
+
+  // @ts-expect-error TS2589: MCP SDK registerTool + zod v3 exceed TS's type instantiation depth. Runtime schema validation is unaffected.
+  server.registerTool('imap_find_email_by_message_id', {
+    description:
+      'Locate an email by its RFC822 Message-ID across folders and return its current { folder, uid } plus basic envelope. ' +
+      'Robust to the message having been moved or archived (IMAP UIDs are folder-relative). ' +
+      'Pass the returned folder + uid to imap_reply_to_email or imap_get_email. ' +
+      'Without `folders`, searches Gmail \\All Mail when present, else INBOX → Archive → Sent → remaining folders.',
+    inputSchema: {
+      accountId: z.string().describe('Account ID'),
+      messageId: z.string().describe('RFC822 Message-ID, with or without angle brackets'),
+      folders: z.array(z.string()).optional().describe('Explicit folders to search, in order (overrides the default order)'),
+    }
+  }, async ({ accountId, messageId, folders }) => {
+    const result = await imapService.findEmailByMessageId(accountId, messageId, folders);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2)
+      }]
+    };
   });
 }

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -113,7 +113,6 @@ export function folderTools(
   });
 
   // Get unread count tool
-  // @ts-expect-error TS2589: MCP SDK registerTool + zod v3 exceed TS's type instantiation depth. Runtime schema validation is unaffected.
   server.registerTool('imap_get_unread_count', {
     description: 'Count unread (unseen) emails per folder, plus a total. Use for "how many unread do I have?" overviews. Defaults to all folders; pass a folders list to limit scope and speed it up.',
     inputSchema: {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,6 +74,19 @@ export interface SearchCriteria {
   flagged?: boolean;
   answered?: boolean;
   draft?: boolean;
+  messageId?: string;
+}
+
+export interface EmailLocation {
+  found: boolean;
+  folder?: string;
+  uid?: number;
+  messageId?: string;
+  subject?: string;
+  from?: string;
+  date?: Date;
+  flags?: string[];
+  foldersSearched?: string[];
 }
 
 export interface ConnectionPool {

--- a/tests/imap-service.test.ts
+++ b/tests/imap-service.test.ts
@@ -296,6 +296,125 @@ describe('ImapService', () => {
         { uid: true }
       );
     });
+
+    it('should build a full bracketed HEADER message-id search clause (Apple needs brackets)', async () => {
+      // default searchMock returns [] → searchEmails returns before fetch
+      await imapService.connect(mockAccount);
+      // input without brackets must be wrapped; case preserved
+      await imapService.searchEmails(mockAccount.id, 'INBOX', { messageId: 'ABC@Host' });
+
+      expect(mockInstance.searchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ header: { 'message-id': '<ABC@Host>' } }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('findEmailByMessageId', () => {
+    it('finds a message in Archive and early-exits before later folders', async () => {
+      mockInstance.listMock.mockResolvedValue([
+        { path: 'INBOX', delimiter: '/', flags: [] },
+        { path: 'Archive', delimiter: '/', flags: ['\\Archive'] },
+        { path: 'Junk', delimiter: '/', flags: ['\\Junk'] },
+      ]);
+
+      let currentFolder = '';
+      mockInstance.getMailboxLockMock.mockImplementation((name: string) => {
+        currentFolder = name;
+        return Promise.resolve({ release: vi.fn() });
+      });
+      mockInstance.searchMock.mockImplementation(() =>
+        Promise.resolve(currentFolder === 'Archive' ? [42] : [])
+      );
+      mockInstance.fetchMock.mockImplementation(() => ({
+        [Symbol.asyncIterator]: () => {
+          let yielded = false;
+          return {
+            next: () => {
+              if (currentFolder !== 'Archive' || yielded) return Promise.resolve({ done: true });
+              yielded = true;
+              return Promise.resolve({
+                value: {
+                  uid: 42,
+                  internalDate: new Date('2026-01-01T00:00:00Z'),
+                  envelope: {
+                    subject: 'Archived mail',
+                    messageId: '<found@host>',
+                    from: [{ name: 'A', address: 'a@host' }],
+                    to: [],
+                  },
+                  flags: new Set<string>(['\\Seen']),
+                },
+                done: false,
+              });
+            },
+          };
+        },
+      }));
+
+      await imapService.connect(mockAccount);
+      const res = await imapService.findEmailByMessageId(mockAccount.id, '<found@host>');
+
+      expect(res.found).toBe(true);
+      expect(res.folder).toBe('Archive');
+      expect(res.uid).toBe(42);
+      expect(res.foldersSearched).toEqual(['INBOX', 'Archive']); // Junk never opened
+    });
+
+    it('rejects a substring false-positive Message-ID (exact verify)', async () => {
+      mockInstance.listMock.mockResolvedValue([
+        { path: 'INBOX', delimiter: '/', flags: [] },
+      ]);
+      mockInstance.searchMock.mockResolvedValue([7]);
+      mockInstance.fetchMock.mockReturnValue({
+        [Symbol.asyncIterator]: () => {
+          let done = false;
+          return {
+            next: () => {
+              if (done) return Promise.resolve({ done: true });
+              done = true;
+              return Promise.resolve({
+                value: {
+                  uid: 7,
+                  internalDate: new Date(),
+                  envelope: {
+                    subject: 'Not it',
+                    messageId: '<prefix-abc@host>', // contains 'abc@host' but != target
+                    from: [{ address: 'x@host' }],
+                    to: [],
+                  },
+                  flags: new Set<string>(),
+                },
+                done: false,
+              });
+            },
+          };
+        },
+      });
+
+      await imapService.connect(mockAccount);
+      const res = await imapService.findEmailByMessageId(mockAccount.id, '<abc@host>');
+
+      expect(res.found).toBe(false);
+    });
+
+    it('uses the Gmail \\All mailbox as the sole primary search target', async () => {
+      // real ImapFlow returns `flags` as a Set, not an array (regression guard)
+      mockInstance.listMock.mockResolvedValue([
+        { path: 'INBOX', delimiter: '/', flags: new Set(['\\HasNoChildren']) },
+        { path: '[Gmail]/All Mail', delimiter: '/', flags: new Set(['\\All']) },
+        { path: '[Gmail]/Trash', delimiter: '/', flags: new Set(['\\Trash']) },
+        { path: '[Gmail]/Sent Mail', delimiter: '/', flags: new Set(['\\Sent']) },
+      ]);
+      mockInstance.searchMock.mockResolvedValue([]); // no hit anywhere
+
+      await imapService.connect(mockAccount);
+      const res = await imapService.findEmailByMessageId(mockAccount.id, '<x@host>');
+
+      expect(res.found).toBe(false);
+      // \All fast path: only All Mail + Trash searched, NOT INBOX or Sent
+      expect(res.foldersSearched).toEqual(['[Gmail]/All Mail', '[Gmail]/Trash']);
+    });
   });
 
   describe('getLatestEmails', () => {


### PR DESCRIPTION
## Summary

Adds `imap_find_email_by_message_id`: given a stable RFC822 **Message-ID**, return the message's current `{folder, uid}`.

IMAP UIDs are folder-relative, so a stored `uid` silently breaks the moment a message is moved or archived. The `Message-ID` header is stable across moves, so this tool lets a caller re-locate a message wherever it now lives (e.g. a thread tracked by Message-ID, re-opened after the user filed the mail away).

## Behaviour

- **Search order**: Gmail `\All` mailbox fast path; otherwise `INBOX` → `\Archive` → `\Sent` → remaining folders.
- **Server quirks handled**: `SEARCH HEADER MESSAGE-ID` is server-specific and only substring-matched. Apple-hosted IMAP (iCloud / custom domains) only matches the full bracketed `<id@host>` form; Gmail matches either. The tool always sends the bracketed form and then **verifies exact equality** against the fetched `envelope.messageId`, rejecting HEADER substring false-positives.
- Returns a basic envelope for the located message plus a `foldersSearched` diagnostic.

## Tests / CI

- Unit tests in `tests/imap-service.test.ts` cover the bracketing, the exact-match verification, and the folder search order.
- Green locally on all four CI gates: **136 tests pass**, `tsc --noEmit --skipLibCheck` clean, `npm run build` emits `dist/index.js` / `dist/setup.js` / `dist/web/server.js`, and `npm audit --audit-level=high` reports **0 vulnerabilities**.

## Notes

- This codebase suppresses a TS2589 *"type instantiation is excessively deep"* diagnostic on several `registerTool` calls via `// @ts-expect-error`. Adding a new tool shifts which call tsc reports the limit on, so this PR adds the directive to the new tool and removes the now-unused one on `imap_get_unread_count` (`folder-tools.ts`). No runtime behaviour change; runtime zod validation is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
