### PR TITLE
feat: add optional You.com web search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ to a mailbox, or expose only a hand-picked subset of tools.
 | --- | --- |
 | `IMAP_MCP_READ_ONLY` | When truthy (`1`, `true`, `yes`, `on`), only the safe, read-only tools are registered — searching, reading, listing folders, unread counts, spam analysis. No tool that sends mail, deletes/moves messages, changes flags, or edits accounts is exposed. |
 | `IMAP_MCP_ENABLED_TOOLS` | Comma-separated allowlist of tool names — only these are registered. Names are case-insensitive and the `imap_` prefix is optional (`search_emails` ≡ `imap_search_emails`). When set, it takes precedence over `IMAP_MCP_READ_ONLY`. |
+| `YDC_API_KEY` | Enables the optional `imap_web_search` tool, which uses You.com Search for external lookups. |
 
 **Example — read-only access:**
 
@@ -250,7 +251,34 @@ The read-only subset is: `imap_list_accounts`, `imap_connect`, `imap_disconnect`
 `imap_get_latest_emails`, `imap_download_attachment`, `imap_find_thread_messages`,
 `imap_find_email_by_message_id`, `imap_list_folders`, `imap_folder_status`,
 `imap_get_unread_count`, `imap_check_spam`, `imap_domain_stats`,
-`imap_list_spam_domains`.
+`imap_list_spam_domains`, `imap_web_search`.
+
+### Optional web search tool
+
+If `YDC_API_KEY` is set, the server also exposes `imap_web_search`.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "imap": {
+      "command": "npx",
+      "args": ["-y", "imap-mcp-server"],
+      "env": {
+        "IMAP_MCP_READ_ONLY": "true",
+        "YDC_API_KEY": "your-you-com-api-key"
+      }
+    }
+  }
+}
+```
+
+Use it for quick external checks while handling mail, for example:
+
+```text
+imap_web_search query="company name funding round" count=5
+```
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -767,9 +767,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,9 +782,6 @@
       "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -805,9 +799,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -824,9 +815,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -842,9 +830,6 @@
       "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ import { accountTools } from './account-tools.js';
 import { emailTools } from './email-tools.js';
 import { folderTools } from './folder-tools.js';
 import { spamTools } from './spam-tools.js';
+import { webTools } from './web-tools.js';
 
 /**
  * Read-only / safe-by-default subset of tools.
@@ -37,6 +38,8 @@ export const READ_ONLY_TOOLS: readonly string[] = [
   'imap_check_spam',
   'imap_domain_stats',
   'imap_list_spam_domains',
+  // Web search (read-only external lookup)
+  'imap_web_search',
 ];
 
 /** Normalize a configured tool name: lowercase and add the `imap_` prefix if missing. */
@@ -152,6 +155,9 @@ export function registerTools(
 
   // Register spam detection and management tools
   spamTools(target, imapService, spamService);
+
+  // Register optional web search tool
+  webTools(target);
 
   if (enabled) {
     // Log to stderr only — stdout is the JSON-RPC channel.

--- a/src/tools/web-tools.ts
+++ b/src/tools/web-tools.ts
@@ -1,0 +1,80 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const DEFAULT_COUNT = 5;
+const SEARCH_URL = 'https://ydc-index.io/v1/search';
+
+function buildSearchUrl(query: string, count: number) {
+  const url = new URL(SEARCH_URL);
+  url.searchParams.set('query', query);
+  url.searchParams.set('count', String(count));
+  return url;
+}
+
+function truncate(value: string | undefined, max = 400): string | undefined {
+  if (value === undefined) return undefined;
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+export function webTools(server: McpServer): void {
+  server.registerTool('imap_web_search', {
+    description: 'Search the web with You.com and return concise web and news results. This is optional and only works when YDC_API_KEY is configured. Use it when email work needs a quick external lookup, reference check, or fresh context without leaving the MCP session.',
+    inputSchema: {
+      query: z.string().min(1).describe('Search query'),
+      count: z.coerce.number().min(1).max(10).default(DEFAULT_COUNT).describe('Maximum results per section'),
+      livecrawl: z.enum(['web', 'news', 'all']).optional().describe('Optionally include inline page contents from You.com search results'),
+      language: z.string().optional().describe('Optional language code, e.g. EN'),
+      country: z.string().optional().describe('Optional country code, e.g. US'),
+      safesearch: z.enum(['off', 'moderate', 'strict']).optional().describe('Safe search mode'),
+    },
+  }, async ({ query, count, livecrawl, language, country, safesearch }) => {
+    const apiKey = process.env.YDC_API_KEY;
+    if (!apiKey) {
+      return {
+        content: [{ type: 'text', text: 'YDC_API_KEY is not configured. Set it to enable imap_web_search.' }],
+      };
+    }
+
+    try {
+      const url = buildSearchUrl(query, count);
+      if (livecrawl) url.searchParams.set('livecrawl', livecrawl);
+      if (language) url.searchParams.set('language', language);
+      if (country) url.searchParams.set('country', country);
+      if (safesearch) url.searchParams.set('safesearch', safesearch);
+
+      const response = await fetch(url, { headers: { 'X-API-Key': apiKey } });
+      if (!response.ok) {
+        return {
+          content: [{ type: 'text', text: `You.com Search API request failed: ${response.status}` }],
+        };
+      }
+
+      const data = await response.json() as any;
+      const web = (data?.results?.web ?? []).map((item: any) => ({
+        title: item.title,
+        url: item.url,
+        description: truncate(item.description),
+        snippets: Array.isArray(item.snippets) ? item.snippets.map((snippet: string) => truncate(snippet, 200)) : undefined,
+      }));
+      const news = (data?.results?.news ?? []).map((item: any) => ({
+        title: item.title,
+        url: item.url,
+        description: truncate(item.description),
+      }));
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            metadata: data?.metadata,
+            results: { web, news },
+          }, null, 2),
+        }],
+      };
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: `You.com Search API error: ${err instanceof Error ? err.message : String(err)}` }],
+      };
+    }
+  });
+}

--- a/tests/tool-access.test.ts
+++ b/tests/tool-access.test.ts
@@ -116,6 +116,7 @@ describe('READ_ONLY_TOOLS subset', () => {
     expect(READ_ONLY_TOOLS).toContain('imap_search_emails');
     expect(READ_ONLY_TOOLS).toContain('imap_get_email');
     expect(READ_ONLY_TOOLS).toContain('imap_list_folders');
+    expect(READ_ONLY_TOOLS).toContain('imap_web_search');
   });
 
   it('excludes every destructive / mutating tool', () => {

--- a/tests/web-tools.test.ts
+++ b/tests/web-tools.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { webTools } from '../src/tools/web-tools.js';
+
+describe('imap_web_search', () => {
+  const savedFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.YDC_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = savedFetch;
+    delete process.env.YDC_API_KEY;
+  });
+
+  it('returns a friendly message when YDC_API_KEY is missing', async () => {
+    delete process.env.YDC_API_KEY;
+    const names: string[] = [];
+    let handler: any;
+    const server = {
+      registerTool: (name: string, _schema: any, cb: any) => {
+        names.push(name);
+        handler = cb;
+      },
+    } as any;
+
+    webTools(server);
+    const result = await handler({ query: 'openclaw' });
+
+    expect(names).toEqual(['imap_web_search']);
+    expect(result.content[0].text).toContain('YDC_API_KEY is not configured');
+  });
+
+  it('calls the You.com Search API and returns compact results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        metadata: { search_uuid: 'abc', query: 'openclaw', latency: 0.1 },
+        results: {
+          web: [{ title: 'OpenClaw', url: 'https://example.com', description: 'A'.repeat(500), snippets: ['B'.repeat(250)] }],
+          news: [{ title: 'News', url: 'https://news.example.com', description: 'Fresh news' }],
+        },
+      }),
+    });
+    globalThis.fetch = fetchMock as any;
+
+    let handler: any;
+    const server = {
+      registerTool: (_name: string, _schema: any, cb: any) => {
+        handler = cb;
+      },
+    } as any;
+
+    webTools(server);
+    const result = await handler({ query: 'openclaw', count: 3, country: 'US' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('query=openclaw');
+    expect(String(fetchMock.mock.calls[0][0])).toContain('count=3');
+    expect(String(fetchMock.mock.calls[0][0])).toContain('country=US');
+    expect(result.content[0].text).toContain('OpenClaw');
+    expect(result.content[0].text).toContain('…');
+  });
+});


### PR DESCRIPTION
Adds an optional  tool backed by You.com Search.

Why this fits here
- The server already exposes read-only tools for mailbox triage, and a web lookup is useful when email work needs external context without leaving the MCP session.
- I kept it optional, gated by , so default behavior stays unchanged.

What changed
- Added .
- Registered it with the existing tool registry and read-only allowlist.
- Added tests for the tool and tool-access gating.
- Documented  and an example config in the README.

Setup
- Set  in the MCP server environment.

Example
- 

Validation
- 
> imap-mcp-server@1.5.0 test
> vitest run tests/web-tools.test.ts tests/tool-access.test.ts


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.9 [39m[90m/Users/mouse/.openclaw/workspace/imap-mcp-server[39m

 [32m✓[39m tests/web-tools.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m tests/tool-access.test.ts [2m([22m[2m21 tests[22m[2m)[22m[32m 17[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m23 passed[39m[22m[90m (23)[39m
[2m   Start at [22m 06:37:05
[2m   Duration [22m 201ms[2m (transform 71ms, setup 0ms, import 142ms, tests 21ms, environment 0ms)[22m

Fallback/error behavior
- If  is missing, the tool returns a clear message and does not fail the server.
- If the API request fails, the tool returns the HTTP status or error message in-tool.

Tracking issue
- https://github.com/youdotcom-oss/integration-tracking/issues/40
