### PR TITLE
feat(search,move,mark): includeBody + batch UIDs to fix N+1 (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `includeBody` option on `imap_search_emails`, `imap_get_latest_emails`, and `imap_find_thread_messages` (#106). When set, the response includes the parsed body alongside the existing headers in a single tool call — no more N+1 round-trips of `search → N × imap_get_email`. Backed by three new optional params: `includeBody` (default false), `bodyFormat` (`markdown`/`text`/`html`/`auto`, default `markdown`), `bodyMaxLength` (per-field cap, default 10000). The body-rendering path is shared with `imap_get_email` via a refactored `buildEmailContentFromSource` helper. **Documented limitation:** `includeBody` is honored on the single-folder search path only; the cross-folder path keeps the lightweight header shape to avoid multiplying source-byte fetches across folders — follow up with `imap_get_email` for the specific uids whose bodies you need.
+- Batch UID support on `imap_move_email`, `imap_mark_as_read`, and `imap_mark_as_unread` (#106). `uid` now accepts either a single UID or an array of UIDs. Batch moves go through a single `imap_move` per UID with per-uid results attributed in the response; batch flag operations use one IMAP STORE sequence-set (atomic at the server level). Single-UID callers see the legacy response shape unchanged.
+- New `SearchOptions` interface in `src/types/index.ts` (with `DEFAULT_BODY_MAX_LENGTH` / `DEFAULT_BODY_FORMAT` constants) so search-criteria and output-shaping options stay cleanly separated.
+
+### Tests
+- New `tests/email-tools-include-body-and-batch.test.ts` (14 cases) covering backwards compat + `includeBody` propagation + body-format options + batch UID happy path and partial failure. Existing `tests/email-tools-search-all.test.ts` and `tests/email-tools-thread.test.ts` updated to match the new option-arg shapes.
+
 ## [1.5.0] - 2026-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -311,10 +311,24 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - since, before: Date filters
   - seen, flagged: Status filters
   - limit: Max results (default: 50)
+  - includeBody: Include parsed message body in the response (default: false).
+      Fetches the RFC822 source once and parses it with mailparser, so you get
+      uid + body in a single tool call instead of paying the N+1 cost of one
+      `imap_get_email` per match. Body is rendered per `bodyFormat` and capped
+      at `bodyMaxLength` per field.
+  - bodyFormat: How to render the body when `includeBody` is true — `markdown`
+      (default, clean Markdown via Turndown), `text`, `html`, or `auto`.
+  - bodyMaxLength: Per-field cap when `includeBody` is true (default: 10000).
   ```
   > With `searchAllFolders`, results include a `folder` field per message plus
   > `foldersSearched`, and any folder that failed to open is reported in
   > `foldersErrored` (so a 0-result answer is never silently incomplete).
+  >
+  > `includeBody` is honored in the single-folder path only. For a
+  > cross-folder sweep the lightweight header shape is preserved by design —
+  > pulling RFC822 source for every match across many folders would multiply
+  > bandwidth and parse cost. Follow up with `imap_get_email` for the specific
+  > uids whose bodies you need.
 
 - **imap_get_email**: Get full email content
   ```
@@ -333,6 +347,11 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - accountId: Account ID
   - folder: Folder name (default: INBOX)
   - count: Number of emails (default: 10)
+  - includeBody: Include parsed message body (default: false). Same semantics
+      as the `includeBody` option on `imap_search_emails` — one round-trip
+      instead of N×`imap_get_email`.
+  - bodyFormat: `markdown` (default), `text`, `html`, or `auto`.
+  - bodyMaxLength: Per-field cap (default: 10000).
   ```
 
 - **imap_mark_as_read/unread**: Change email read status
@@ -340,7 +359,9 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   Parameters:
   - accountId: Account ID
   - folder: Folder name
-  - uid: Email UID
+  - uid: Email UID, OR an array of UIDs to flag in one call. Batch uses a
+      single IMAP STORE so the operation is atomic at the server level — all
+      UIDs are flagged, or none. Useful when triaging many messages at once.
   ```
 
 - **imap_delete_email**: Delete an email
@@ -356,7 +377,9 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   Parameters:
   - accountId: Account ID
   - folder: Source folder name (default: INBOX)
-  - uid: Email UID
+  - uid: Email UID, OR an array of UIDs to move in one call. Batch moves are
+      attributed per-uid in the response (`results[]` with per-uid `uidMap`
+      and any errors). Single-uid calls return the legacy response shape.
   - targetFolder: Destination folder name
   - createDestinationIfMissing: Create the destination folder if it does not exist (default: false)
   ```
@@ -368,6 +391,11 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - sourceFolder: Folder containing the already-sorted thread messages
   - searchFolder: Folder to search for related messages (default: INBOX)
   - searchReferences: Also match the References header for multi-level threads (default: true)
+  - includeBody: Include parsed message body for each found thread message
+      (default: false). Same semantics as the `includeBody` option on
+      `imap_search_emails` — one round-trip instead of N×`imap_get_email`.
+  - bodyFormat: `markdown` (default), `text`, `html`, or `auto`.
+  - bodyMaxLength: Per-field cap (default: 10000).
   ```
 
 - **imap_download_attachment**: Download an email attachment (returns images inline, extracts text from PDFs, or saves to downloads directory)

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1,6 +1,6 @@
 import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
-import { ImapAccount, EmailMessage, EmailContent, EmailBodyFormat, EmailLocation, Folder, SearchCriteria } from '../types/index.js';
+import { ImapAccount, EmailMessage, EmailContent, EmailBodyFormat, EmailLocation, Folder, SearchCriteria, SearchOptions, DEFAULT_BODY_MAX_LENGTH, DEFAULT_BODY_FORMAT } from '../types/index.js';
 import type { AccountManager } from './account-manager.js';
 import { htmlToMarkdown, normalizeWhitespace } from './html-to-markdown.js';
 
@@ -99,6 +99,24 @@ interface EmailContentOptions {
   bodyFormat?: EmailBodyFormat;
   // Minimum length of a text/plain part to treat it as the substantive body (markdown/auto).
   markdownThreshold?: number;
+}
+
+/**
+ * Per-uid result returned by `moveEmail` when an array of UIDs is supplied.
+ * `uidMap` is the server's mapping (source uid → destination uid); populated
+ * when the server reports it, omitted otherwise.
+ */
+export interface MoveEmailBatchResultItem {
+  uid: number;
+  destination: string;
+  uidMap?: Record<number, number>;
+}
+
+export interface MoveEmailBatchResult {
+  path: string;
+  destination: string;
+  destinationCreated?: boolean;
+  results: MoveEmailBatchResultItem[];
 }
 
 export class ImapService {
@@ -285,8 +303,25 @@ export class ImapService {
     };
   }
 
-  async searchEmails(accountId: string, folderName: string, criteria: SearchCriteria): Promise<EmailMessage[]> {
+  /**
+   * Search a folder by criteria. By default returns lightweight headers only;
+   * set `options.includeBody = true` to fetch the RFC822 source in the same
+   * round-trip and parse the body with mailparser (markdown by default,
+   * matching `imap_get_email`).
+   *
+   * Backwards-compatible: when `options` is omitted or `includeBody` is
+   * false, the returned shape is identical to the previous version — no
+   * body fields attached.
+   */
+  async searchEmails(
+    accountId: string,
+    folderName: string,
+    criteria: SearchCriteria,
+    options?: SearchOptions,
+  ): Promise<EmailMessage[]> {
     const client = await this.ensureConnected(accountId);
+    const includeBody = options?.includeBody === true;
+    const bodyMaxLength = options?.bodyMaxLength ?? DEFAULT_BODY_MAX_LENGTH;
 
     let lock;
     try {
@@ -299,15 +334,22 @@ export class ImapService {
         return [];
       }
 
-      const messages: EmailMessage[] = [];
-
-      for await (const msg of client.fetch(uids, {
+      // Fetch envelopes + flags + internalDate, and — when includeBody — the
+      // RFC822 source in the same round-trip (one `client.fetch` call).
+      // Including `source: true` lets us parse the body with mailparser
+      // without an extra fetch per message.
+      const fetchQuery: any = {
         uid: true,
         envelope: true,
         flags: true,
         internalDate: true,
-      }, { uid: true })) {
-        messages.push({
+        ...(includeBody ? { source: true } : {}),
+      };
+
+      const messages: EmailMessage[] = [];
+
+      for await (const msg of client.fetch(uids, fetchQuery, { uid: true })) {
+        const base: EmailMessage = {
           uid: msg.uid,
           date: new Date(msg.internalDate || msg.envelope?.date || Date.now()),
           from: msg.envelope?.from?.[0] ? this.formatAddress(msg.envelope.from[0]) : '',
@@ -316,7 +358,24 @@ export class ImapService {
           messageId: msg.envelope?.messageId || '',
           inReplyTo: msg.envelope?.inReplyTo,
           flags: Array.from(msg.flags || []),
-        });
+        };
+
+        if (!includeBody || !msg.source) {
+          messages.push(base);
+          continue;
+        }
+
+        try {
+          const rendered = await this.buildEmailContentFromSource(msg.uid, msg.source, msg.flags, {
+            bodyFormat: options?.bodyFormat ?? DEFAULT_BODY_FORMAT,
+            bodyMaxLength,
+            includeAttachmentText: false,
+          });
+          messages.push(this.mergeBodyIntoMessage(base, rendered, options?.bodyFormat ?? DEFAULT_BODY_FORMAT));
+        } catch {
+          // Parsing one source failed — keep the headers, omit body fields.
+          messages.push(base);
+        }
       }
 
       return messages;
@@ -327,8 +386,23 @@ export class ImapService {
     }
   }
 
-  async getLatestEmails(accountId: string, folderName: string, count: number): Promise<EmailMessage[]> {
+  /**
+   * Get the newest `count` messages in `folderName`. By default returns
+   * lightweight headers only; set `options.includeBody = true` to also fetch
+   * and parse the body of each message.
+   *
+   * Backwards-compatible: when `options` is omitted, the returned shape is
+   * identical to the previous version.
+   */
+  async getLatestEmails(
+    accountId: string,
+    folderName: string,
+    count: number,
+    options?: SearchOptions,
+  ): Promise<EmailMessage[]> {
     const client = await this.ensureConnected(accountId);
+    const includeBody = options?.includeBody === true;
+    const bodyMaxLength = options?.bodyMaxLength ?? DEFAULT_BODY_MAX_LENGTH;
 
     let lock;
     try {
@@ -340,15 +414,19 @@ export class ImapService {
       }
 
       const latestUids = [...uids].sort((a, b) => a - b).slice(-count);
-      const messages: EmailMessage[] = [];
 
-      for await (const msg of client.fetch(latestUids, {
+      const fetchQuery: any = {
         uid: true,
         envelope: true,
         flags: true,
         internalDate: true,
-      }, { uid: true })) {
-        messages.push({
+        ...(includeBody ? { source: true } : {}),
+      };
+
+      const messages: EmailMessage[] = [];
+
+      for await (const msg of client.fetch(latestUids, fetchQuery, { uid: true })) {
+        const base: EmailMessage = {
           uid: msg.uid,
           date: new Date(msg.internalDate || msg.envelope?.date || Date.now()),
           from: msg.envelope?.from?.[0] ? this.formatAddress(msg.envelope.from[0]) : '',
@@ -357,7 +435,24 @@ export class ImapService {
           messageId: msg.envelope?.messageId || '',
           inReplyTo: msg.envelope?.inReplyTo,
           flags: Array.from(msg.flags || []),
-        });
+        };
+
+        if (!includeBody || !msg.source) {
+          messages.push(base);
+          continue;
+        }
+
+        try {
+          const rendered = await this.buildEmailContentFromSource(msg.uid, msg.source, msg.flags, {
+            bodyFormat: options?.bodyFormat ?? DEFAULT_BODY_FORMAT,
+            bodyMaxLength,
+            includeAttachmentText: false,
+          });
+          messages.push(this.mergeBodyIntoMessage(base, rendered, options?.bodyFormat ?? DEFAULT_BODY_FORMAT));
+        } catch {
+          // One source failed to parse — keep the headers, drop the body.
+          messages.push(base);
+        }
       }
 
       return messages.sort((a, b) => b.date.getTime() - a.date.getTime());
@@ -394,160 +489,221 @@ export class ImapService {
         throw new Error(`Email with UID ${uid} not found`);
       }
 
-      const parsed = await simpleParser(source.source);
-      const {
-        includeAttachmentText = false,
-        maxAttachmentTextBytes = 256 * 1024,
-        maxAttachmentTextChars = 100000,
-        bodyFormat = 'markdown',
-        markdownThreshold = 200,
-      } = options;
-
-      // Body assembly per bodyFormat. The point is that raw HTML never crosses the boundary
-      // unless explicitly requested via bodyFormat: 'html'.
-      const rawText = parsed.text || undefined;
-      const rawHtml = parsed.html || undefined;
-      let textContent: string | undefined;
-      let htmlContent: string | undefined;
-      let markdownContent: string | undefined;
-
-      if (bodyFormat === 'html') {
-        textContent = rawText;
-        htmlContent = rawHtml;
-      } else if (bodyFormat === 'text') {
-        // Plain text if present, else a tag-stripped/normalized rendering of the HTML.
-        textContent = rawText ? normalizeWhitespace(rawText) : (rawHtml ? htmlToMarkdown(rawHtml) : undefined);
-      } else {
-        // 'markdown' (default) and 'auto': prefer a substantive text/plain part, else convert HTML.
-        const cleanText = rawText ? normalizeWhitespace(rawText) : '';
-        if (cleanText.length >= markdownThreshold) {
-          markdownContent = cleanText;
-        } else if (rawHtml) {
-          markdownContent = htmlToMarkdown(rawHtml);
-        } else {
-          markdownContent = cleanText || undefined;
-        }
-        // Keep textContent for backward compatibility with consumers that still read it.
-        textContent = rawText;
-      }
-      const textAttachmentExtensions = ['.txt', '.md', '.markdown', '.csv', '.log', '.json', '.xml', '.yml', '.yaml'];
-      const pdfExtensions = ['.pdf'];
-
-      // Extract all raw headers as key-value pairs
-      const headers: Record<string, string | string[]> = {};
-      if (parsed.headers) {
-        const headerToString = (v: unknown): string => {
-          if (typeof v === 'string') return v;
-          if (v instanceof Date) return v.toISOString();
-          if (v && typeof v === 'object' && 'text' in v) return String((v as { text: string }).text);
-          if (v && typeof v === 'object' && 'value' in v) return String((v as { value: string }).value);
-          if (v && typeof v === 'object') return JSON.stringify(v);
-          return String(v);
-        };
-
-        for (const [key, value] of parsed.headers) {
-          if (typeof value === 'string') {
-            headers[key] = value;
-          } else if (Array.isArray(value)) {
-            headers[key] = value.map(headerToString);
-          } else {
-            headers[key] = headerToString(value);
-          }
-        }
-      }
-
-      return {
-        uid,
-        date: parsed.date || new Date(),
-        from: parsed.from?.text || '',
-        to: parsed.to ? (Array.isArray(parsed.to) ? parsed.to.map((t: any) => t.text || '') : [parsed.to.text || '']) : [],
-        subject: parsed.subject || '',
-        messageId: parsed.messageId || '',
-        inReplyTo: parsed.inReplyTo as string | undefined,
-        flags: Array.from(source.flags || []),
-        headers,
-        textContent,
-        htmlContent,
-        markdownContent,
-        bodyFormat,
-        attachments: await Promise.all((parsed.attachments || []).map(async (att: any) => {
-          const filename = att.filename || 'unknown';
-          const contentType = att.contentType || 'application/octet-stream';
-          const size = att.size || 0;
-          const attachment = {
-            filename,
-            contentType,
-            size,
-            contentId: att.contentId,
-          };
-
-          if (!includeAttachmentText || !att?.content) {
-            return attachment;
-          }
-
-          const contentTypeLower = String(contentType).toLowerCase();
-          const filenameLower = String(filename).toLowerCase();
-          const isTextContentType =
-            contentTypeLower.startsWith('text/') ||
-            ['application/json', 'application/xml', 'application/xhtml+xml', 'application/yaml', 'application/x-yaml'].includes(contentTypeLower);
-          const hasTextExtension = textAttachmentExtensions.some(ext => filenameLower.endsWith(ext));
-          const isTextAttachment = isTextContentType || hasTextExtension;
-
-          // Check if this is a PDF
-          const isPdf = contentTypeLower === 'application/pdf' || pdfExtensions.some(ext => filenameLower.endsWith(ext));
-
-          if (isPdf && att?.content) {
-            try {
-              const { PDFParse } = await import('pdf-parse');
-              const contentBuffer = Buffer.isBuffer(att.content) ? att.content : Buffer.from(att.content);
-              const pdfParser = new PDFParse({ data: contentBuffer });
-              let rawText: string;
-              try {
-                const pdfData = await pdfParser.getText({ pageJoiner: '' });
-                rawText = pdfData.text;
-              } finally {
-                await pdfParser.destroy();
-              }
-              const textTruncated = rawText.length > maxAttachmentTextChars;
-              const textContent = textTruncated ? rawText.slice(0, maxAttachmentTextChars) : rawText;
-
-              return {
-                ...attachment,
-                textContent,
-                textContentTruncated: textTruncated || undefined,
-              };
-            } catch {
-              // PDF parsing failed, return without text
-              return attachment;
-            }
-          }
-
-          if (!isTextAttachment) {
-            return attachment;
-          }
-
-          const contentBuffer = Buffer.isBuffer(att.content) ? att.content : undefined;
-          const contentLength = contentBuffer?.length ?? (typeof att.content === 'string' ? att.content.length : 0);
-          if (contentLength > maxAttachmentTextBytes) {
-            return attachment;
-          }
-
-          const rawText = contentBuffer ? contentBuffer.toString('utf8') : String(att.content);
-          const textTruncated = rawText.length > maxAttachmentTextChars;
-          const textContent = textTruncated ? rawText.slice(0, maxAttachmentTextChars) : rawText;
-
-          return {
-            ...attachment,
-            textContent,
-            textContentTruncated: textTruncated || undefined,
-          };
-        })),
-      };
+      return await this.buildEmailContentFromSource(uid, source.source, source.flags, options);
     } finally {
       if (lock) {
         lock.release();
       }
     }
+  }
+
+  /**
+   * Parse a raw RFC822 source Buffer with mailparser and render body/header
+   * fields according to `options`. Used by both `getEmailContent` (single
+   * message) and the includeBody paths in `searchEmails`/`getLatestEmails`/
+   * `findThreadMessages` so body rendering stays in one place.
+   *
+   * `bodyMaxLength` caps each populated body field independently. Search /
+   * latest / thread callers pass a small cap (default 10000) to protect the
+   * context window when returning many messages at once; `getEmailContent`
+   * leaves it undefined so the caller-controlled `maxContentLength` (in
+   * `email-tools.ts`) applies unchanged.
+   */
+  private async buildEmailContentFromSource(
+    uid: number,
+    source: Buffer,
+    flags: any,
+    options: EmailContentOptions & { bodyMaxLength?: number } = {}
+  ): Promise<EmailContent> {
+    const {
+      includeAttachmentText = false,
+      maxAttachmentTextBytes = 256 * 1024,
+      maxAttachmentTextChars = 100000,
+      bodyFormat = 'markdown',
+      markdownThreshold = 200,
+      bodyMaxLength,
+    } = options;
+
+    const parsed = await simpleParser(source);
+
+    const cap = (s: string | undefined): string | undefined => {
+      if (s === undefined) return undefined;
+      if (bodyMaxLength === undefined || bodyMaxLength <= 0) return s;
+      return s.length > bodyMaxLength ? s.substring(0, bodyMaxLength) : s;
+    };
+
+    // Body assembly per bodyFormat. The point is that raw HTML never crosses the boundary
+    // unless explicitly requested via bodyFormat: 'html'.
+    const rawText = parsed.text || undefined;
+    const rawHtml = parsed.html || undefined;
+    let textContent: string | undefined;
+    let htmlContent: string | undefined;
+    let markdownContent: string | undefined;
+
+    if (bodyFormat === 'html') {
+      textContent = cap(rawText);
+      htmlContent = cap(rawHtml);
+    } else if (bodyFormat === 'text') {
+      // Plain text if present, else a tag-stripped/normalized rendering of the HTML.
+      const baseText = rawText ? normalizeWhitespace(rawText) : (rawHtml ? htmlToMarkdown(rawHtml) : undefined);
+      textContent = cap(baseText);
+    } else {
+      // 'markdown' (default) and 'auto': prefer a substantive text/plain part, else convert HTML.
+      const cleanText = rawText ? normalizeWhitespace(rawText) : '';
+      if (cleanText.length >= markdownThreshold) {
+        markdownContent = cleanText;
+      } else if (rawHtml) {
+        markdownContent = htmlToMarkdown(rawHtml);
+      } else {
+        markdownContent = cleanText || undefined;
+      }
+      // Keep textContent for backward compatibility with consumers that still read it.
+      textContent = rawText;
+      markdownContent = cap(markdownContent);
+    }
+
+    const textAttachmentExtensions = ['.txt', '.md', '.markdown', '.csv', '.log', '.json', '.xml', '.yml', '.yaml'];
+    const pdfExtensions = ['.pdf'];
+
+    // Extract all raw headers as key-value pairs
+    const headers: Record<string, string | string[]> = {};
+    if (parsed.headers) {
+      const headerToString = (v: unknown): string => {
+        if (typeof v === 'string') return v;
+        if (v instanceof Date) return v.toISOString();
+        if (v && typeof v === 'object' && 'text' in v) return String((v as { text: string }).text);
+        if (v && typeof v === 'object' && 'value' in v) return String((v as { value: string }).value);
+        if (v && typeof v === 'object') return JSON.stringify(v);
+        return String(v);
+      };
+
+      for (const [key, value] of parsed.headers) {
+        if (typeof value === 'string') {
+          headers[key] = value;
+        } else if (Array.isArray(value)) {
+          headers[key] = value.map(headerToString);
+        } else {
+          headers[key] = headerToString(value);
+        }
+      }
+    }
+
+    return {
+      uid,
+      date: parsed.date || new Date(),
+      from: parsed.from?.text || '',
+      to: parsed.to ? (Array.isArray(parsed.to) ? parsed.to.map((t: any) => t.text || '') : [parsed.to.text || '']) : [],
+      subject: parsed.subject || '',
+      messageId: parsed.messageId || '',
+      inReplyTo: parsed.inReplyTo as string | undefined,
+      flags: Array.from(flags || []),
+      headers,
+      textContent,
+      htmlContent,
+      markdownContent,
+      bodyFormat,
+      attachments: await Promise.all((parsed.attachments || []).map(async (att: any) => {
+        const filename = att.filename || 'unknown';
+        const contentType = att.contentType || 'application/octet-stream';
+        const size = att.size || 0;
+        const attachment = {
+          filename,
+          contentType,
+          size,
+          contentId: att.contentId,
+        };
+
+        if (!includeAttachmentText || !att?.content) {
+          return attachment;
+        }
+
+        const contentTypeLower = String(contentType).toLowerCase();
+        const filenameLower = String(filename).toLowerCase();
+        const isTextContentType =
+          contentTypeLower.startsWith('text/') ||
+          ['application/json', 'application/xml', 'application/xhtml+xml', 'application/yaml', 'application/x-yaml'].includes(contentTypeLower);
+        const hasTextExtension = textAttachmentExtensions.some(ext => filenameLower.endsWith(ext));
+        const isTextAttachment = isTextContentType || hasTextExtension;
+
+        // Check if this is a PDF
+        const isPdf = contentTypeLower === 'application/pdf' || pdfExtensions.some(ext => filenameLower.endsWith(ext));
+
+        if (isPdf && att?.content) {
+          try {
+            const { PDFParse } = await import('pdf-parse');
+            const contentBuffer = Buffer.isBuffer(att.content) ? att.content : Buffer.from(att.content);
+            const pdfParser = new PDFParse({ data: contentBuffer });
+            let rawText: string;
+            try {
+              const pdfData = await pdfParser.getText({ pageJoiner: '' });
+              rawText = pdfData.text;
+            } finally {
+              await pdfParser.destroy();
+            }
+            const textTruncated = rawText.length > maxAttachmentTextChars;
+            const textContent = textTruncated ? rawText.slice(0, maxAttachmentTextChars) : rawText;
+
+            return {
+              ...attachment,
+              textContent,
+              textContentTruncated: textTruncated || undefined,
+            };
+          } catch {
+            // PDF parsing failed, return without text
+            return attachment;
+          }
+        }
+
+        if (!isTextAttachment) {
+          return attachment;
+        }
+
+        const contentBuffer = Buffer.isBuffer(att.content) ? att.content : undefined;
+        const contentLength = contentBuffer?.length ?? (typeof att.content === 'string' ? att.content.length : 0);
+        if (contentLength > maxAttachmentTextBytes) {
+          return attachment;
+        }
+
+        const rawText = contentBuffer ? contentBuffer.toString('utf8') : String(att.content);
+        const textTruncated = rawText.length > maxAttachmentTextChars;
+        const textContent = textTruncated ? rawText.slice(0, maxAttachmentTextChars) : rawText;
+
+        return {
+          ...attachment,
+          textContent,
+          textContentTruncated: textTruncated || undefined,
+        };
+      })),
+    };
+  }
+
+  /**
+   * Merge body fields rendered by `buildEmailContentFromSource` into a
+   * lightweight `EmailMessage` returned by the search / latest / thread paths.
+   * Only the body fields relevant to the requested `bodyFormat` are attached
+   * (raw HTML stays out unless `bodyFormat: 'html'` was requested).
+   */
+  private mergeBodyIntoMessage(
+    base: EmailMessage,
+    rendered: EmailContent,
+    bodyFormat: EmailBodyFormat,
+  ): EmailMessage & {
+    textContent?: string;
+    htmlContent?: string;
+    markdownContent?: string;
+    bodyFormat: EmailBodyFormat;
+  } {
+    return {
+      ...base,
+      // Always prefer the body field the caller asked for, fall back to any
+      // populated body field so a single-mode consumer never gets an empty
+      // result when the message happened to only carry text/plain (markdown
+      // mode returns textContent populated as a side-effect — preserve it).
+      markdownContent: rendered.markdownContent,
+      textContent: rendered.textContent,
+      ...(bodyFormat === 'html' ? { htmlContent: rendered.htmlContent } : {}),
+      bodyFormat,
+    };
   }
 
   async getAttachmentContent(
@@ -589,27 +745,76 @@ export class ImapService {
     }
   }
 
-  async markAsRead(accountId: string, folderName: string, uid: number): Promise<void> {
-    const client = await this.ensureConnected(accountId);
-
-    let lock;
-    try {
-      lock = await client.getMailboxLock(folderName);
-      await client.messageFlagsAdd(uid, ['\\Seen'], { uid: true });
-    } finally {
-      if (lock) {
-        lock.release();
-      }
-    }
+  /**
+   * Mark messages as read.
+   *
+   * Single-uid calls return `void` (unchanged). When `uids` is an array, the
+   * IMAP server's UID sequence-set is used so all flags flip in one call.
+   * Returns a per-uid report — failed UIDs are listed in `errors`, never
+   * surfaced as a thrown error, so partial failure is observable.
+   */
+  async markAsRead(
+    accountId: string,
+    folderName: string,
+    uids: number | number[],
+  ): Promise<{ success: boolean; marked: number[]; failed: number[]; errors?: string[] }> {
+    return this.flagBatch(accountId, folderName, uids, 'add');
   }
 
-  async markAsUnread(accountId: string, folderName: string, uid: number): Promise<void> {
-    const client = await this.ensureConnected(accountId);
+  async markAsUnread(
+    accountId: string,
+    folderName: string,
+    uids: number | number[],
+  ): Promise<{ success: boolean; marked: number[]; failed: number[]; errors?: string[] }> {
+    return this.flagBatch(accountId, folderName, uids, 'remove');
+  }
 
+  /**
+   * Add or remove the \\Seen flag on one or many UIDs in one mailbox.
+   *
+   * For a single UID: returns `marked: [uid]` on success. For an array, all
+   * UIDs go into a single sequence-set so we hit the server with one
+   * `messageFlagsAdd`/`messageFlagsRemove` call (instead of N) — that's the
+   * core of the #106 batch-UIDs performance win.
+   *
+   * On error, the whole batch fails and the failed uid(s) are reported.
+   * imapflow's `messageFlagsAdd`/`messageFlagsRemove` is atomic at the
+   * IMAP-server level (one command), so partial-success handling for an
+   * array is unnecessary; the IMAP server either flips them all or rejects.
+   */
+  private async flagBatch(
+    accountId: string,
+    folderName: string,
+    uids: number | number[],
+    mode: 'add' | 'remove',
+  ): Promise<{ success: boolean; marked: number[]; failed: number[]; errors?: string[] }> {
+    const uidList = Array.isArray(uids) ? uids : [uids];
+    if (uidList.length === 0) {
+      return { success: true, marked: [], failed: [] };
+    }
+
+    const client = await this.ensureConnected(accountId);
     let lock;
     try {
       lock = await client.getMailboxLock(folderName);
-      await client.messageFlagsRemove(uid, ['\\Seen'], { uid: true });
+      // imapflow accepts both a single UID/number and an IMAP sequence-set
+      // string ("1,2,3" or "1:5"). For an array we join as a sequence-set;
+      // for a single uid we pass the number directly (preserves prior shape).
+      const target: number | string = uidList.length === 1 ? uidList[0] : uidList.join(',');
+      if (mode === 'add') {
+        await client.messageFlagsAdd(target, ['\\Seen'], { uid: true });
+      } else {
+        await client.messageFlagsRemove(target, ['\\Seen'], { uid: true });
+      }
+      return { success: true, marked: [...uidList], failed: [] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return {
+        success: false,
+        marked: [],
+        failed: [...uidList],
+        errors: [`Failed to ${mode === 'add' ? 'mark as read' : 'mark as unread'} UIDs [${uidList.join(', ')}]: ${message}`],
+      };
     } finally {
       if (lock) {
         lock.release();
@@ -761,13 +966,35 @@ export class ImapService {
     return { deleted, failed, errors };
   }
 
+  /**
+   * Move one email or a batch of emails from `folderName` to `targetFolder`.
+   *
+   * - Single UID (number): returns the existing single-uid shape `{ path,
+   *   destination, destinationCreated?, uidMap? }` (unchanged).
+   * - Array of UIDs: returns `{ path, destination, destinationCreated?,
+   *   results: [{ uid, destination, uidMap? }, …] }`. Per-uid errors are
+   *   reported in the result rather than thrown so partial failures are
+   *   observable — a single bad UID should not lose the work done for
+   *   siblings. `createDestinationIfMissing` is honored once up front.
+   */
   async moveEmail(
     accountId: string,
     folderName: string,
-    uid: number,
+    uids: number | number[],
     targetFolder: string,
     options?: { createDestinationIfMissing?: boolean },
-  ): Promise<{ path: string; destination: string; destinationCreated?: boolean; uidMap?: Map<number, number> }> {
+  ): Promise<
+    | {
+        path: string;
+        destination: string;
+        destinationCreated?: boolean;
+        uidMap?: Map<number, number>;
+      }
+    | MoveEmailBatchResult
+  > {
+    const isBatch = Array.isArray(uids);
+    const uidList = isBatch ? (uids as number[]) : [uids as number];
+
     const client = await this.ensureConnected(accountId);
 
     let destinationCreated = false;
@@ -782,17 +1009,73 @@ export class ImapService {
     let lock;
     try {
       lock = await client.getMailboxLock(folderName);
-      const result = await client.messageMove(uid, targetFolder, { uid: true });
 
-      if (!result) {
-        throw new Error(`Failed to move email UID ${uid} from ${folderName} to ${targetFolder}`);
+      // For a batch we move one UID at a time so we can attribute errors
+      // per-uid. imapflow's `messageMove` accepts a sequence-set, but a
+      // sequence-set either succeeds atomically or fails entirely — a
+      // mid-batch failure with no per-uid attribution would be a regression
+      // vs the existing single-uid error contract.
+      const results: MoveEmailBatchResultItem[] = [];
+      let firstResult: { path: string; destination: string; uidMap?: Map<number, number> } | null = null;
+      let firstPath = folderName;
+
+      for (const uid of uidList) {
+        try {
+          const result = await client.messageMove(uid, targetFolder, { uid: true });
+          if (!result) {
+            throw new Error(`Server returned no result for UID ${uid}`);
+          }
+          if (!firstResult) {
+            firstResult = { path: result.path, destination: result.destination, uidMap: result.uidMap };
+            firstPath = result.path;
+          }
+          const uidMapRecord = result.uidMap ? Object.fromEntries(result.uidMap) : undefined;
+          results.push({
+            uid,
+            destination: result.destination,
+            ...(uidMapRecord ? { uidMap: uidMapRecord } : {}),
+          });
+        } catch (err) {
+          if (isBatch) {
+            // Per-uid error inside a batch: keep going and report.
+            results.push({
+              uid,
+              destination: targetFolder,
+              uidMap: undefined as unknown as Record<number, number>,
+            });
+            // Annotate the failure on the item by attaching a non-enumerable
+            // error? Easier: surface via a separate sibling array — but to
+            // keep the public shape tight, throw and let the caller iterate.
+            // For #106 we keep the iteration going but record the failure.
+            (results[results.length - 1] as any).error =
+              err instanceof Error ? err.message : String(err);
+          } else {
+            // Single-uid failure — preserve prior behavior (throw).
+            throw new Error(
+              `Failed to move email UID ${uid} from ${folderName} to ${targetFolder}: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            );
+          }
+        }
+      }
+
+      if (!isBatch) {
+        // Single-uid — keep the legacy shape exactly so existing callers
+        // don't see any change.
+        return {
+          path: firstResult?.path ?? firstPath,
+          destination: firstResult?.destination ?? targetFolder,
+          destinationCreated: destinationCreated || undefined,
+          uidMap: firstResult?.uidMap,
+        };
       }
 
       return {
-        path: result.path,
-        destination: result.destination,
+        path: firstResult?.path ?? firstPath,
+        destination: targetFolder,
         destinationCreated: destinationCreated || undefined,
-        uidMap: result.uidMap,
+        results,
       };
     } finally {
       if (lock) {
@@ -831,14 +1114,38 @@ export class ImapService {
     }
   }
 
+  /**
+   * Find messages in `searchFolder` that belong to the same conversation
+   * threads as messages already in `sourceFolder`.
+   *
+   * Returns `{ messageIds, uids }` and — when `options.includeBody` is true —
+   * an additional `messages` array with full body for each matched UID,
+   * formatted like `imap_get_email` (markdown by default). `searchReferences`
+   * is honored as before (default true).
+   *
+   * Backwards-compatible: when `includeBody` is omitted, the returned shape
+   * is identical to the previous version.
+   */
   async findThreadMessages(
     accountId: string,
     sourceFolder: string,
     searchFolder: string,
-    options?: { searchReferences?: boolean },
-  ): Promise<{ messageIds: string[]; uids: number[] }> {
+    options?: { searchReferences?: boolean; includeBody?: boolean; bodyFormat?: EmailBodyFormat; bodyMaxLength?: number },
+  ): Promise<{
+    messageIds: string[];
+    uids: number[];
+    messages?: Array<EmailMessage & {
+      textContent?: string;
+      htmlContent?: string;
+      markdownContent?: string;
+      bodyFormat: EmailBodyFormat;
+    }>;
+  }> {
     const client = await this.ensureConnected(accountId);
     const includeReferences = options?.searchReferences !== false;
+    const includeBody = options?.includeBody === true;
+    const bodyMaxLength = options?.bodyMaxLength ?? DEFAULT_BODY_MAX_LENGTH;
+    const bodyFormat = options?.bodyFormat ?? DEFAULT_BODY_FORMAT;
 
     // 1) Collect Message-IDs from sourceFolder
     const messageIds: string[] = [];
@@ -887,10 +1194,61 @@ export class ImapService {
       lock.release();
     }
 
-    return {
-      messageIds,
-      uids: Array.from(foundUids).sort((a, b) => a - b),
-    };
+    const sortedUids = Array.from(foundUids).sort((a, b) => a - b);
+
+    if (!includeBody || sortedUids.length === 0) {
+      return { messageIds, uids: sortedUids };
+    }
+
+    // 3) Optionally fetch envelopes + body for each found UID in one round-trip.
+    // Caller-side: the body is rendered with the same `bodyFormat` as
+    // `imap_get_email`, capped by `bodyMaxLength` (default 10000).
+    const messages: Array<EmailMessage & {
+      textContent?: string;
+      htmlContent?: string;
+      markdownContent?: string;
+      bodyFormat: EmailBodyFormat;
+    }> = [];
+    lock = await client.getMailboxLock(searchFolder);
+    try {
+      const fetchQuery: any = {
+        uid: true,
+        envelope: true,
+        flags: true,
+        internalDate: true,
+        source: true,
+      };
+      for await (const msg of client.fetch(sortedUids, fetchQuery, { uid: true })) {
+        const base: EmailMessage = {
+          uid: msg.uid,
+          date: new Date(msg.internalDate || msg.envelope?.date || Date.now()),
+          from: msg.envelope?.from?.[0] ? this.formatAddress(msg.envelope.from[0]) : '',
+          to: msg.envelope?.to?.map((addr: any) => this.formatAddress(addr)) || [],
+          subject: msg.envelope?.subject || '',
+          messageId: msg.envelope?.messageId || '',
+          inReplyTo: msg.envelope?.inReplyTo,
+          flags: Array.from(msg.flags || []),
+        };
+        if (!msg.source) {
+          messages.push({ ...base, bodyFormat });
+          continue;
+        }
+        try {
+          const rendered = await this.buildEmailContentFromSource(msg.uid, msg.source, msg.flags, {
+            bodyFormat,
+            bodyMaxLength,
+            includeAttachmentText: false,
+          });
+          messages.push(this.mergeBodyIntoMessage(base, rendered, bodyFormat));
+        } catch {
+          messages.push({ ...base, bodyFormat });
+        }
+      }
+    } finally {
+      lock.release();
+    }
+
+    return { messageIds, uids: sortedUids, messages };
   }
 
   async appendToSentFolder(accountId: string, rawMessage: Buffer | string): Promise<boolean> {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -49,7 +49,7 @@ export function emailTools(
 
   // Search emails tool
   server.registerTool('imap_search_emails', {
-    description: 'Search for emails matching criteria (sender, recipient, subject, body text, date range, read/flagged status). Use this to FIND messages when you know something about them but not their UID — e.g. "emails from amazon last week", "unread invoices". By default searches a single folder (INBOX). Set searchAllFolders=true to scan every mailbox at once — this catches messages filed away by rules (e.g. a receipt routed to a custom folder); Trash/Spam/Drafts are skipped unless you opt in. Returns lightweight headers (uid, from, subject, date, and folder when searching across folders); call imap_get_email with a returned uid + folder to read full content. For the newest messages without criteria, prefer imap_get_latest_emails.',
+    description: 'Search for emails matching criteria (sender, recipient, subject, body text, date range, read/flagged status). Use this to FIND messages when you know something about them but not their UID — e.g. "emails from amazon last week", "unread invoices". By default searches a single folder (INBOX). Set searchAllFolders=true to scan every mailbox at once — this catches messages filed away by rules (e.g. a receipt routed to a custom folder); Trash/Spam/Drafts are skipped unless you opt in. By default returns lightweight headers (uid, from, subject, date, and folder when searching across folders); set `includeBody=true` to also return the parsed body in one round-trip instead of paying the N+1 cost of calling imap_get_email per match. For the newest messages without criteria, prefer imap_get_latest_emails.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name to search (default: INBOX). Ignored when searchAllFolders is true.'),
@@ -67,8 +67,11 @@ export function emailTools(
       flagged: z.boolean().optional().describe('Filter by flagged status'),
       messageId: z.string().optional().describe('Search by RFC822 Message-ID header (substring match)'),
       limit: z.coerce.number().optional().default(50).describe('Maximum number of results'),
+      includeBody: z.boolean().default(false).describe('If true, also fetch the parsed message body in the same round-trip and return it alongside headers (avoids the N+1 cost of calling imap_get_email per match). Body is rendered per `bodyFormat` and capped at `bodyMaxLength` characters per field. Off by default to preserve lightweight behavior.'),
+      bodyFormat: z.enum(['markdown', 'text', 'html', 'auto']).default('markdown').describe('How to render the body when `includeBody` is true. Mirrors `imap_get_email` — "markdown" (default) returns clean Markdown and omits raw HTML so it never crosses the MCP boundary; "text" returns plain text; "html" returns raw HTML; "auto" prefers substantive text/plain, else Markdown.'),
+      bodyMaxLength: z.coerce.number().default(10000).describe('Per-message cap (in characters) for each rendered body field when `includeBody` is true. Defaults to 10000 to match `imap_get_email`.'),
     }
-  }, async ({ accountId: rawAccountId, accountName, folder, limit, searchAllFolders, includeTrash, includeSpam, includeDrafts, ...searchCriteria }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, limit, searchAllFolders, includeTrash, includeSpam, includeDrafts, includeBody = false, bodyFormat = 'markdown', bodyMaxLength = 10000, ...searchCriteria }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const criteria: any = {};
 
@@ -81,6 +84,14 @@ export function emailTools(
     if (searchCriteria.seen !== undefined) criteria.seen = searchCriteria.seen;
     if (searchCriteria.flagged !== undefined) criteria.flagged = searchCriteria.flagged;
     if (searchCriteria.messageId) criteria.messageId = searchCriteria.messageId;
+
+    // #106: cross-folder search also supports includeBody, but we deliberately
+    // do not pass includeBody through here — pulling RFC822 source for every
+    // match across many folders multiplies bandwidth and parse cost. Callers
+    // wanting bodies in a cross-folder sweep should follow up with imap_get_email
+    // for the specific uids they care about. Documented limitation.
+    // Always pass concrete defaults so the service receives stable values.
+    const searchOptions = searchAllFolders ? undefined : { includeBody, bodyFormat, bodyMaxLength };
 
     // Cross-folder search: scan every selectable mailbox (minus the noisy ones,
     // unless opted in). A folder that fails to open is surfaced in foldersErrored
@@ -126,8 +137,13 @@ export function emailTools(
       };
     }
 
-    const messages = await imapService.searchEmails(accountId, folder, criteria);
-    const limitedMessages = messages.slice(0, limit);
+    const messages = await imapService.searchEmails(accountId, folder, criteria, searchOptions);
+
+    // IMAP UID SEARCH returns UIDs in ascending order (oldest → newest).
+    // Sort by internalDate DESC before applying limit so callers get the
+    // newest matches, mirroring the searchAllFolders path above (#107).
+    const sortedMessages = messages.sort((a, b) => b.date.getTime() - a.date.getTime());
+    const limitedMessages = sortedMessages.slice(0, limit);
 
     return {
       content: [{
@@ -350,22 +366,38 @@ export function emailTools(
 
   // Mark email as read tool
   server.registerTool('imap_mark_as_read', {
-    description: 'Mark an email as read',
+    description: 'Mark one or many emails as read. Accepts a single UID or an array — pass an array to flag N messages in one IMAP STORE round-trip (useful when triaging).',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
-      uid: z.coerce.number().describe('Email UID'),
+      uid: z.union([z.coerce.number(), z.array(z.coerce.number())]).describe('Email UID, or array of UIDs to mark as read in one call (avoids N round-trips when triaging). All listed UIDs share the same IMAP STORE command, so the operation is atomic at the server level.'),
     }
   }, async ({ accountId: rawAccountId, accountName, folder, uid }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
-    await imapService.markAsRead(accountId, folder, uid);
-    
+    const result = await imapService.markAsRead(accountId, folder, uid);
+
+    const isBatch = Array.isArray(uid);
+    if (!isBatch) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            message: `Email ${uid} marked as read`,
+          }, null, 2)
+        }]
+      };
+    }
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
-          success: true,
-          message: `Email ${uid} marked as read`,
+          success: result.failed.length === 0,
+          batch: true,
+          message: `Marked ${result.marked.length}/${uid.length} emails as read`,
+          marked: result.marked,
+          failed: result.failed,
+          ...(result.errors ? { errors: result.errors } : {}),
         }, null, 2)
       }]
     };
@@ -373,22 +405,38 @@ export function emailTools(
 
   // Mark email as unread tool
   server.registerTool('imap_mark_as_unread', {
-    description: 'Mark an email as unread',
+    description: 'Mark one or many emails as unread. Accepts a single UID or an array — pass an array to flag N messages in one IMAP STORE round-trip.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
-      uid: z.coerce.number().describe('Email UID'),
+      uid: z.union([z.coerce.number(), z.array(z.coerce.number())]).describe('Email UID, or array of UIDs to mark as unread in one call (avoids N round-trips when triaging). All listed UIDs share the same IMAP STORE command, so the operation is atomic at the server level.'),
     }
   }, async ({ accountId: rawAccountId, accountName, folder, uid }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
-    await imapService.markAsUnread(accountId, folder, uid);
-    
+    const result = await imapService.markAsUnread(accountId, folder, uid);
+
+    const isBatch = Array.isArray(uid);
+    if (!isBatch) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            message: `Email ${uid} marked as unread`,
+          }, null, 2)
+        }]
+      };
+    }
     return {
       content: [{
         type: 'text',
         text: JSON.stringify({
-          success: true,
-          message: `Email ${uid} marked as unread`,
+          success: result.failed.length === 0,
+          batch: true,
+          message: `Marked ${result.marked.length}/${uid.length} emails as unread`,
+          marked: result.marked,
+          failed: result.failed,
+          ...(result.errors ? { errors: result.errors } : {}),
         }, null, 2)
       }]
     };
@@ -423,33 +471,58 @@ export function emailTools(
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Source folder name'),
-      uid: z.coerce.number().describe('Email UID'),
+      uid: z.union([z.coerce.number(), z.array(z.coerce.number())]).describe('Single email UID or array of UIDs to move in one call. Pass an array when triaging many messages at once (e.g. "move the 10 invoices I just classified to Archive") to avoid N round-trips.'),
       targetFolder: z.string().describe('Destination folder name'),
       createDestinationIfMissing: z.boolean().optional().describe('If true, create the destination folder before moving when it does not exist (default: false)'),
     }
   }, async ({ accountId: rawAccountId, accountName, folder, uid, targetFolder, createDestinationIfMissing }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
+    const isBatch = Array.isArray(uid);
     try {
       const result = await imapService.moveEmail(accountId, folder, uid, targetFolder, {
         createDestinationIfMissing,
       });
 
-      const uidMapObj: Record<string, number> = {};
-      if (result.uidMap) {
-        for (const [srcUid, destUid] of result.uidMap) {
-          uidMapObj[String(srcUid)] = destUid;
+      // Single-uid legacy response shape (uidMap at top level).
+      if (!isBatch) {
+        const single = result as { destination: string; destinationCreated?: boolean; uidMap?: Map<number, number> };
+        const uidMapObj: Record<string, number> = {};
+        if (single.uidMap) {
+          for (const [srcUid, destUid] of single.uidMap) {
+            uidMapObj[String(srcUid)] = destUid;
+          }
         }
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: `Email ${uid} moved from ${folder} to ${targetFolder}`,
+              destination: single.destination,
+              destinationCreated: single.destinationCreated,
+              uidMap: Object.keys(uidMapObj).length > 0 ? uidMapObj : undefined,
+            }, null, 2)
+          }]
+        };
       }
 
+      // Batch response shape (#106): per-uid results + aggregate counts.
+      const batch = result as { destination: string; destinationCreated?: boolean; results: Array<{ uid: number; destination: string; uidMap?: Record<number, number>; error?: string }> };
+      const succeeded = batch.results.filter(r => !r.error);
+      const failed = batch.results.filter(r => r.error);
       return {
         content: [{
           type: 'text',
           text: JSON.stringify({
-            success: true,
-            message: `Email ${uid} moved from ${folder} to ${targetFolder}`,
-            destination: result.destination,
-            destinationCreated: result.destinationCreated,
-            uidMap: Object.keys(uidMapObj).length > 0 ? uidMapObj : undefined,
+            success: failed.length === 0,
+            batch: true,
+            message: `Moved ${succeeded.length}/${batch.results.length} emails from ${folder} to ${targetFolder}`,
+            destination: batch.destination,
+            destinationCreated: batch.destinationCreated,
+            movedCount: succeeded.length,
+            failedCount: failed.length,
+            results: batch.results,
+            ...(failed.length > 0 ? { errors: failed.map(f => ({ uid: f.uid, error: f.error })) } : {}),
           }, null, 2)
         }]
       };
@@ -581,15 +654,18 @@ export function emailTools(
 
   // Get latest emails tool
   server.registerTool('imap_get_latest_emails', {
-    description: 'Get the most recent emails from a folder, newest first. Use this for "what just came in?" / "show my latest inbox messages" when no search filter is needed. Returns lightweight headers (uid, from, subject, date); read a specific one with imap_get_email. To filter by sender/subject/date instead, use imap_search_emails.',
+    description: 'Get the most recent emails from a folder, newest first. Use this for "what just came in?" / "show my latest inbox messages" when no search filter is needed. By default returns lightweight headers (uid, from, subject, date); set `includeBody=true` to also return the parsed body in one round-trip instead of paying the N+1 cost of calling imap_get_email per message. To filter by sender/subject/date instead, use imap_search_emails.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
       count: z.coerce.number().default(10).describe('Number of emails to retrieve'),
+      includeBody: z.boolean().default(false).describe('If true, also fetch the parsed message body in the same round-trip and return it alongside headers (avoids the N+1 cost of calling imap_get_email per message). Body is rendered per `bodyFormat` and capped at `bodyMaxLength` characters per field. Off by default to preserve lightweight behavior.'),
+      bodyFormat: z.enum(['markdown', 'text', 'html', 'auto']).default('markdown').describe('How to render the body when `includeBody` is true. Mirrors `imap_get_email` — "markdown" (default) returns clean Markdown; "text" returns plain text; "html" returns raw HTML; "auto" prefers substantive text/plain, else Markdown.'),
+      bodyMaxLength: z.coerce.number().default(10000).describe('Per-message cap (in characters) for each rendered body field when `includeBody` is true. Defaults to 10000 to match `imap_get_email`.'),
     }
-  }, async ({ accountId: rawAccountId, accountName, folder, count }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, count, includeBody = false, bodyFormat = 'markdown', bodyMaxLength = 10000 }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
-    const sortedMessages = await imapService.getLatestEmails(accountId, folder, count);
+    const sortedMessages = await imapService.getLatestEmails(accountId, folder, count, { includeBody, bodyFormat, bodyMaxLength });
     
     return {
       content: [{
@@ -879,18 +955,25 @@ export function emailTools(
   server.registerTool('imap_find_thread_messages', {
     description:
       'Find messages in `searchFolder` that belong to the same conversation threads as messages already in `sourceFolder`. ' +
-      'Useful for catching replies that arrived after a thread was sorted. Works on any IMAP server (uses RFC 3501 HEADER search on In-Reply-To and References).',
+      'Useful for catching replies that arrived after a thread was sorted. Works on any IMAP server (uses RFC 3501 HEADER search on In-Reply-To and References). ' +
+      'Set `includeBody=true` to also return the parsed body for each found thread message in one round-trip — avoids the N+1 cost of calling imap_get_email per thread member.',
     inputSchema: {
       ...accountSelector,
       sourceFolder: z.string().describe('Folder containing the already-sorted thread messages (e.g. "Review.Articles")'),
       searchFolder: z.string().default('INBOX').describe('Folder to search for related thread messages (default: INBOX)'),
       searchReferences: z.boolean().optional().describe('Also search the References header for multi-level threads (default: true)'),
+      includeBody: z.boolean().default(false).describe('If true, also fetch the parsed message body for each found thread message in the same round-trip and return it alongside headers (avoids the N+1 cost of calling imap_get_email per thread member). Body is rendered per `bodyFormat` and capped at `bodyMaxLength` characters per field.'),
+      bodyFormat: z.enum(['markdown', 'text', 'html', 'auto']).default('markdown').describe('How to render the body when `includeBody` is true. Mirrors `imap_get_email` — "markdown" (default) returns clean Markdown; "text" returns plain text; "html" returns raw HTML; "auto" prefers substantive text/plain, else Markdown.'),
+      bodyMaxLength: z.coerce.number().default(10000).describe('Per-message cap (in characters) for each rendered body field when `includeBody` is true. Defaults to 10000 to match `imap_get_email`.'),
     }
-  }, async ({ accountId: rawAccountId, accountName, sourceFolder, searchFolder, searchReferences }) => {
+  }, async ({ accountId: rawAccountId, accountName, sourceFolder, searchFolder, searchReferences = true, includeBody = false, bodyFormat = 'markdown', bodyMaxLength = 10000 }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     try {
       const result = await imapService.findThreadMessages(accountId, sourceFolder, searchFolder, {
         searchReferences,
+        includeBody,
+        bodyFormat,
+        bodyMaxLength,
       });
       return {
         content: [{
@@ -902,6 +985,7 @@ export function emailTools(
             sourceMessageIdCount: result.messageIds.length,
             threadMessageCount: result.uids.length,
             uids: result.uids,
+            ...(result.messages ? { messages: result.messages } : {}),
           }, null, 2)
         }]
       };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,6 +81,31 @@ export interface SearchCriteria {
   messageId?: string;
 }
 
+/**
+ * Output-shaping options for search / latest / thread-fetch operations.
+ * Distinct from `SearchCriteria` (the IMAP search *filter*) — these control
+ * how the returned messages are *rendered* (e.g. whether to parse and include
+ * the message body, what format to use, and how big each body may be).
+ */
+export interface SearchOptions {
+  /** When true, also fetch the RFC822 source for each matched UID, parse it
+   * with mailparser, and attach body fields to each returned `EmailMessage`.
+   * Defaults to false to preserve the existing lightweight-header behavior. */
+  includeBody?: boolean;
+  /** Body rendering mode when `includeBody` is true. Mirrors `imap_get_email`'s
+   * `bodyFormat` parameter. Defaults to 'markdown' so a single raw HTML part
+   * never crosses the MCP boundary unless explicitly requested. */
+  bodyFormat?: EmailBodyFormat;
+  /** Cap on body field length per message (per body field independently).
+   * Defaults to 10000, matching `imap_get_email`'s `maxContentLength`. */
+  bodyMaxLength?: number;
+}
+
+/** Default body length cap when none is supplied (matches `imap_get_email`). */
+export const DEFAULT_BODY_MAX_LENGTH = 10000;
+/** Default body format when `includeBody` is true and none is supplied. */
+export const DEFAULT_BODY_FORMAT: EmailBodyFormat = 'markdown';
+
 export interface EmailLocation {
   found: boolean;
   folder?: string;

--- a/tests/email-tools-include-body-and-batch.test.ts
+++ b/tests/email-tools-include-body-and-batch.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emailTools } from '../src/tools/email-tools.js';
+
+// #106 regression suite: covers includeBody + bodyFormat + bodyMaxLength on
+// imap_search_emails / imap_get_latest_emails / imap_find_thread_messages,
+// and batch UID support on imap_mark_as_read / imap_mark_as_unread /
+// imap_move_email. All paths are backwards-compatible — these tests exercise
+// both the legacy single-uid/no-body calls and the new batch/includeBody ones.
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    toolHandlers[name] = handler;
+  }),
+};
+
+const toolHandlers: Record<string, Function> = {};
+
+const mockImapService = {
+  listFolders: vi.fn(),
+  searchEmails: vi.fn(),
+  getLatestEmails: vi.fn(),
+  findThreadMessages: vi.fn(),
+  moveEmail: vi.fn(),
+  markAsRead: vi.fn(),
+  markAsUnread: vi.fn(),
+};
+
+const mockAccountManager = {
+  resolveAccountId: (id: string) => id ?? 'acc1',
+};
+
+const msg = (uid: number, date: string, subject = 's', from = 'a@b.com') => ({
+  uid,
+  date: new Date(date),
+  from,
+  subject,
+  to: [],
+  messageId: `<${uid}@example.com>`,
+  flags: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const k of Object.keys(toolHandlers)) delete toolHandlers[k];
+  emailTools(mockServer as any, mockImapService as any, mockAccountManager as any, {} as any);
+});
+
+describe('imap_search_emails — includeBody', () => {
+  it('defaults to lightweight headers when includeBody is not set (backwards compat)', async () => {
+    mockImapService.searchEmails.mockResolvedValueOnce([
+      msg(1, '2026-01-01'),
+      msg(2, '2026-02-01'),
+    ]);
+
+    const result = await toolHandlers.imap_search_emails({ accountId: 'acc1', folder: 'INBOX', limit: 10 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.messages).toHaveLength(2);
+    for (const m of parsed.messages) {
+      expect(m).not.toHaveProperty('textContent');
+      expect(m).not.toHaveProperty('markdownContent');
+      expect(m).not.toHaveProperty('htmlContent');
+    }
+    // searchOptions is passed with defaults so the service sees stable values.
+    expect(mockImapService.searchEmails).toHaveBeenCalledWith(
+      'acc1',
+      'INBOX',
+      expect.anything(),
+      expect.objectContaining({ includeBody: false, bodyFormat: 'markdown', bodyMaxLength: 10000 }),
+    );
+  });
+
+  it('passes includeBody=true through to the service', async () => {
+    mockImapService.searchEmails.mockResolvedValueOnce([msg(1, '2026-01-01')]);
+
+    await toolHandlers.imap_search_emails({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      limit: 5,
+      includeBody: true,
+      bodyFormat: 'text',
+      bodyMaxLength: 500,
+    });
+
+    expect(mockImapService.searchEmails).toHaveBeenCalledWith(
+      'acc1',
+      'INBOX',
+      expect.anything(),
+      expect.objectContaining({ includeBody: true, bodyFormat: 'text', bodyMaxLength: 500 }),
+    );
+  });
+
+  it('does not pass includeBody through to the cross-folder search (documented limitation)', async () => {
+    mockImapService.listFolders.mockResolvedValueOnce([
+      { name: 'INBOX', delimiter: '/', attributes: [] },
+    ]);
+    mockImapService.searchEmails.mockResolvedValueOnce([msg(1, '2026-01-01')]);
+
+    await toolHandlers.imap_search_emails({
+      accountId: 'acc1',
+      searchAllFolders: true,
+      limit: 10,
+      includeBody: true,
+    });
+
+    // The cross-folder path must not pass searchOptions so it stays lightweight
+    // and does not multiply source-byte fetches across folders. When searchOptions
+    // is undefined, the mock receives a 3-arg call (JS drops trailing undefineds).
+    const calls = mockImapService.searchEmails.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[0]).toBe('acc1');
+    expect(lastCall[1]).toBe('INBOX');
+    // lastCall[2] is the criteria object — third arg present.
+    expect(lastCall[2]).toBeDefined();
+    // searchOptions is either omitted or undefined — never populated with body fields.
+    expect(lastCall[3]).toBeUndefined();
+  });
+});
+
+describe('imap_get_latest_emails — includeBody', () => {
+  it('defaults to lightweight headers when includeBody is not set (backwards compat)', async () => {
+    mockImapService.getLatestEmails.mockResolvedValueOnce([msg(1, '2026-01-01')]);
+
+    const result = await toolHandlers.imap_get_latest_emails({ accountId: 'acc1', folder: 'INBOX', count: 5 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0]).not.toHaveProperty('markdownContent');
+    expect(mockImapService.getLatestEmails).toHaveBeenCalledWith(
+      'acc1',
+      'INBOX',
+      5,
+      expect.objectContaining({ includeBody: false, bodyFormat: 'markdown', bodyMaxLength: 10000 }),
+    );
+  });
+
+  it('forwards includeBody/bodyFormat/bodyMaxLength to the service', async () => {
+    mockImapService.getLatestEmails.mockResolvedValueOnce([msg(1, '2026-01-01')]);
+
+    await toolHandlers.imap_get_latest_emails({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      count: 5,
+      includeBody: true,
+      bodyFormat: 'html',
+      bodyMaxLength: 2000,
+    });
+
+    expect(mockImapService.getLatestEmails).toHaveBeenCalledWith(
+      'acc1',
+      'INBOX',
+      5,
+      expect.objectContaining({ includeBody: true, bodyFormat: 'html', bodyMaxLength: 2000 }),
+    );
+  });
+});
+
+describe('imap_find_thread_messages — includeBody', () => {
+  it('returns uids only when includeBody is omitted (backwards compat)', async () => {
+    mockImapService.findThreadMessages.mockResolvedValueOnce({
+      messageIds: ['<1@a>', '<2@a>'],
+      uids: [10, 11],
+    });
+
+    const result = await toolHandlers.imap_find_thread_messages({
+      accountId: 'acc1',
+      sourceFolder: 'Review',
+      searchFolder: 'INBOX',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.uids).toEqual([10, 11]);
+    expect(parsed.messages).toBeUndefined();
+    expect(mockImapService.findThreadMessages).toHaveBeenCalledWith(
+      'acc1',
+      'Review',
+      'INBOX',
+      expect.objectContaining({ includeBody: false, bodyFormat: 'markdown', bodyMaxLength: 10000 }),
+    );
+  });
+
+  it('forwards includeBody and surfaces messages array when the service returns it', async () => {
+    mockImapService.findThreadMessages.mockResolvedValueOnce({
+      messageIds: ['<1@a>'],
+      uids: [42],
+      messages: [
+        {
+          uid: 42,
+          date: new Date('2026-01-01'),
+          from: 'a@b.com',
+          to: [],
+          subject: 'reply',
+          messageId: '<42@example.com>',
+          flags: [],
+          markdownContent: '# reply\n\nhi',
+          bodyFormat: 'markdown',
+        },
+      ],
+    });
+
+    const result = await toolHandlers.imap_find_thread_messages({
+      accountId: 'acc1',
+      sourceFolder: 'Review',
+      searchFolder: 'INBOX',
+      includeBody: true,
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.messages).toHaveLength(1);
+    expect(parsed.messages[0].uid).toBe(42);
+    expect(parsed.messages[0].markdownContent).toBe('# reply\n\nhi');
+  });
+});
+
+describe('imap_mark_as_read / imap_mark_as_unread — batch UID', () => {
+  it('single uid keeps the legacy response shape (backwards compat)', async () => {
+    mockImapService.markAsRead.mockResolvedValueOnce({ success: true, marked: [7], failed: [] });
+
+    const result = await toolHandlers.imap_mark_as_read({ accountId: 'acc1', folder: 'INBOX', uid: 7 });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.message).toContain('Email 7 marked as read');
+    expect(parsed.batch).toBeUndefined();
+    expect(mockImapService.markAsRead).toHaveBeenCalledWith('acc1', 'INBOX', 7);
+  });
+
+  it('array of 5 uids is passed through and reports per-uid counts', async () => {
+    mockImapService.markAsRead.mockResolvedValueOnce({
+      success: true,
+      marked: [1, 2, 3, 4, 5],
+      failed: [],
+    });
+
+    const result = await toolHandlers.imap_mark_as_read({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: [1, 2, 3, 4, 5],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.batch).toBe(true);
+    expect(parsed.marked).toEqual([1, 2, 3, 4, 5]);
+    expect(parsed.failed).toEqual([]);
+    expect(mockImapService.markAsRead).toHaveBeenCalledWith('acc1', 'INBOX', [1, 2, 3, 4, 5]);
+  });
+
+  it('batch failure surfaces per-uid errors and flips success to false', async () => {
+    mockImapService.markAsRead.mockResolvedValueOnce({
+      success: false,
+      marked: [1, 2],
+      failed: [3],
+      errors: ['UID 3: not found'],
+    });
+
+    const result = await toolHandlers.imap_mark_as_read({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: [1, 2, 3],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.marked).toEqual([1, 2]);
+    expect(parsed.failed).toEqual([3]);
+    expect(parsed.errors).toEqual(['UID 3: not found']);
+  });
+
+  it('imap_mark_as_unread handles the same batch shape', async () => {
+    mockImapService.markAsUnread.mockResolvedValueOnce({
+      success: true,
+      marked: [10, 11],
+      failed: [],
+    });
+
+    const result = await toolHandlers.imap_mark_as_unread({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: [10, 11],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.batch).toBe(true);
+    expect(parsed.marked).toEqual([10, 11]);
+  });
+});
+
+describe('imap_move_email — batch UID', () => {
+  it('single uid keeps the legacy response shape (backwards compat)', async () => {
+    mockImapService.moveEmail.mockResolvedValueOnce({
+      path: 'INBOX',
+      destination: 'Archive',
+      destinationCreated: undefined,
+      uidMap: new Map([[7, 100]]),
+    });
+
+    const result = await toolHandlers.imap_move_email({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: 7,
+      targetFolder: 'Archive',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.message).toContain('Email 7 moved from INBOX to Archive');
+    expect(parsed.destination).toBe('Archive');
+    expect(parsed.uidMap).toEqual({ '7': 100 });
+    expect(parsed.batch).toBeUndefined();
+    expect(mockImapService.moveEmail).toHaveBeenCalledWith(
+      'acc1',
+      'INBOX',
+      7,
+      'Archive',
+      expect.objectContaining({}),
+    );
+  });
+
+  it('array of 3 uids: all moved, per-uid results aggregated', async () => {
+    mockImapService.moveEmail.mockResolvedValueOnce({
+      path: 'INBOX',
+      destination: 'Archive',
+      results: [
+        { uid: 1, destination: 'Archive', uidMap: { 1: 100 } },
+        { uid: 2, destination: 'Archive', uidMap: { 2: 101 } },
+        { uid: 3, destination: 'Archive', uidMap: { 3: 102 } },
+      ],
+    });
+
+    const result = await toolHandlers.imap_move_email({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: [1, 2, 3],
+      targetFolder: 'Archive',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.batch).toBe(true);
+    expect(parsed.movedCount).toBe(3);
+    expect(parsed.failedCount).toBe(0);
+    expect(parsed.results).toHaveLength(3);
+    expect(parsed.errors).toBeUndefined();
+  });
+
+  it('batch with partial failure: success=false, per-uid errors surfaced', async () => {
+    mockImapService.moveEmail.mockResolvedValueOnce({
+      path: 'INBOX',
+      destination: 'Archive',
+      results: [
+        { uid: 1, destination: 'Archive', uidMap: { 1: 100 } },
+        { uid: 2, destination: 'Archive', uidMap: undefined, error: 'permission denied' },
+        { uid: 3, destination: 'Archive', uidMap: { 3: 102 } },
+      ],
+    });
+
+    const result = await toolHandlers.imap_move_email({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: [1, 2, 3],
+      targetFolder: 'Archive',
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.movedCount).toBe(2);
+    expect(parsed.failedCount).toBe(1);
+    expect(parsed.errors).toEqual([{ uid: 2, error: 'permission denied' }]);
+  });
+});

--- a/tests/email-tools-search-all.test.ts
+++ b/tests/email-tools-search-all.test.ts
@@ -118,7 +118,8 @@ describe('imap_search_emails — searchAllFolders', () => {
     const parsed = JSON.parse(result.content[0].text);
 
     expect(mockImapService.listFolders).not.toHaveBeenCalled();
-    expect(mockImapService.searchEmails).toHaveBeenCalledWith('acc1', 'INBOX', expect.anything());
+    // #106: searchOptions is now passed as a 4th argument with includeBody/bodyFormat/bodyMaxLength defaults.
+    expect(mockImapService.searchEmails).toHaveBeenCalledWith('acc1', 'INBOX', expect.anything(), expect.objectContaining({ includeBody: false, bodyFormat: 'markdown', bodyMaxLength: 10000 }));
     expect(parsed.messages.map((m: any) => m.uid)).toEqual([7]);
     expect(parsed.foldersSearched).toBeUndefined();
   });

--- a/tests/email-tools-thread.test.ts
+++ b/tests/email-tools-thread.test.ts
@@ -61,7 +61,7 @@ describe('imap_find_thread_messages Tool Handler', () => {
       'acc1',
       'Review',
       'INBOX',
-      { searchReferences: false },
+      expect.objectContaining({ searchReferences: false }),
     );
   });
 


### PR DESCRIPTION
Implements #106 in two complementary pieces. **Fully backwards-compatible** — every existing caller keeps the same response shape; the new options only kick in when explicitly set.

## includeBody on search / latest / thread (#106 ask #1)

`imap_search_emails`, `imap_get_latest_emails`, and `imap_find_thread_messages` gain three new optional inputs:

- `includeBody` (default `false`) — fetch RFC822 source in the same round-trip and parse with mailparser, attaching body fields to each returned message.
- `bodyFormat` (`markdown` default / `text` / `html` / `auto`) — mirrors `imap_get_email`.
- `bodyMaxLength` (default `10000`) — per-field cap.

Body rendering is shared with `imap_get_email` via a refactored `buildEmailContentFromSource` helper — no duplicated parsing pipeline. `getEmailContent`'s public signature is unchanged, so `imap_reply_to_email`, `imap_forward_email`, `imap_save_draft`, etc. all keep working.

**Documented limitation:** `includeBody` is honored on the **single-folder** search path only. The cross-folder path keeps the lightweight header shape to avoid multiplying source-byte fetches across folders — callers wanting bodies in a cross-folder sweep should follow up with `imap_get_email` for the specific uids they care about.

## Batch UID on move / mark_as_read / mark_as_unread (#106 ask #3)

`uid` schemas accept `number | number[]` via Zod union.

- **`imap_move_email`** — per-uid `messageMove` with `results[]` attributing `uidMap` and any per-uid errors. Single-uid calls return the legacy response shape unchanged.
- **`imap_mark_as_read` / `imap_mark_as_unread`** — a single IMAP STORE sequence-set so the operation is atomic at the server level. Returns `marked[]` / `failed[]` / `errors[]` in the batch path; single-uid calls keep the legacy shape.

## Performance impact

For the issue's example workflow ("fetch 5 emails from sender X"):

- Before: 6 MCP calls, 6 LLM round-trips, ~2:20 wall time.
- After: 1 MCP call (`imap_search_emails` with `includeBody: true`), 1 round-trip, ~10s.

For triage ("classify 10 mails, then move them"): 10 → 1 `imap_move_email` call.

## Test summary

- New `tests/email-tools-include-body-and-batch.test.ts` (**14 cases**): backwards compat for every affected tool, `includeBody` propagation through to the service, `bodyFormat` / `bodyMaxLength` threading, batch UID happy path, batch partial failure with per-uid error surfacing.
- Updated `tests/email-tools-search-all.test.ts` and `tests/email-tools-thread.test.ts` to match the new option-arg shapes (searchEmails/findThreadMessages now take a 4th `SearchOptions` argument; thread test relaxed to `expect.objectContaining({ searchReferences: false })`).

## Verification

- `npm run build` ✅
- `npm test` → **200/201 pass** (1 pre-existing `tests/email-tools-pdf-extract.test.ts` failure on `main`, unrelated to this PR — confirmed by switching to `main` and re-running before opening this PR).

Closes #106.