### PR TITLE
feat(spam): header-based spam indicators in imap_check_spam (#115)

### DIFF
--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -119,6 +119,45 @@ export interface MoveEmailBatchResult {
   results: MoveEmailBatchResultItem[];
 }
 
+/**
+ * Parse a raw RFC 822 header block into a map of lowercased header name → value.
+ * Handles header folding (continuation lines starting with whitespace) and
+ * joins repeated headers (e.g. multiple `Received`/`Authentication-Results`)
+ * with newlines. Intentionally lightweight — no MIME word decoding — because
+ * callers use it for plain string/regex matching (spam header analysis).
+ */
+export function parseRawHeaders(raw: Buffer | string): Record<string, string> {
+  const text = typeof raw === 'string' ? raw : raw.toString('utf8');
+  const headers: Record<string, string> = {};
+  let current: { key: string; value: string } | null = null;
+
+  const commit = () => {
+    if (!current) return;
+    const key = current.key.toLowerCase().trim();
+    const val = current.value.trim();
+    if (key) {
+      headers[key] = headers[key] !== undefined ? `${headers[key]}\n${val}` : val;
+    }
+    current = null;
+  };
+
+  for (const line of text.split(/\r?\n/)) {
+    if (line === '') continue;
+    if (/^[ \t]/.test(line)) {
+      // Folded continuation of the previous header.
+      if (current) current.value += ` ${line.trim()}`;
+      continue;
+    }
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    commit();
+    current = { key: line.slice(0, idx), value: line.slice(idx + 1) };
+  }
+  commit();
+
+  return headers;
+}
+
 export class ImapService {
   private connections: Map<string, ConnectionState> = new Map();
   private reconnectAttempts: Map<string, number> = new Map();
@@ -379,6 +418,38 @@ export class ImapService {
       }
 
       return messages;
+    } finally {
+      if (lock) {
+        lock.release();
+      }
+    }
+  }
+
+  /**
+   * Fetch the raw headers for a set of UIDs in a single round-trip and return a
+   * map of uid → parsed header record (lowercased header names). Does **not**
+   * fetch or parse message bodies — used for lightweight header analysis such
+   * as spam indicator checks. UIDs with no headers returned are omitted.
+   */
+  async fetchHeadersForUids(
+    accountId: string,
+    folderName: string,
+    uids: number[],
+  ): Promise<Map<number, Record<string, string>>> {
+    const result = new Map<number, Record<string, string>>();
+    if (!uids || uids.length === 0) {
+      return result;
+    }
+
+    const client = await this.ensureConnected(accountId);
+    let lock;
+    try {
+      lock = await client.getMailboxLock(folderName);
+      for await (const msg of client.fetch(uids, { uid: true, headers: true }, { uid: true })) {
+        if (!msg.headers) continue;
+        result.set(msg.uid, parseRawHeaders(msg.headers));
+      }
+      return result;
     } finally {
       if (lock) {
         lock.release();

--- a/src/services/spam-service.ts
+++ b/src/services/spam-service.ts
@@ -66,6 +66,28 @@ const SUSPICIOUS_PATTERNS: RegExp[] = [
   /^(xn--)/i, // Punycode domains (internationalized, often used in phishing)
 ];
 
+// Substrings that identify bulk-mail / mass-mailer software in X-Mailer or
+// User-Agent headers. Matched case-insensitively as plain substrings — no
+// external lookups. These tools are legal and sometimes used legitimately, so
+// a hit is a low/medium-confidence indicator, never a definitive verdict.
+const BULK_MAILER_SIGNATURES: string[] = [
+  'sendy',
+  'phpmailer',
+  'phplist',
+  'powermta',
+  'acelle',
+  'sendblaster',
+  'mumara',
+  'gammadyne',
+  'advanced mass sender',
+  'atomic mail sender',
+  'turbo-mailer',
+  'mass mailer',
+  'bulk mailer',
+  'x-bulkmailer',
+  'easymail',
+];
+
 export interface SpamCheckResult {
   email: string;
   domain: string;
@@ -78,6 +100,19 @@ export interface DomainStats {
   domain: string;
   count: number;
   emails: Array<{ uid: number; from: string; subject: string }>;
+}
+
+/**
+ * A single header-based spam indicator. `header` is the offending header name,
+ * `value` the (possibly normalized) offending value, `reason` a short
+ * human/LLM-readable explanation, and `severity` how strong the signal is.
+ * These are heuristic indicators, not a definitive spam verdict.
+ */
+export interface HeaderRedFlag {
+  header: string;
+  value: string;
+  reason: string;
+  severity: 'high' | 'medium' | 'low';
 }
 
 export class SpamService {
@@ -201,6 +236,158 @@ export class SpamService {
       .sort((a, b) => b.count - a.count);
 
     return { spam, clean, domainStats };
+  }
+
+  /**
+   * Run deterministic, dependency-free checks over an email's raw headers and
+   * return any spam indicators found. Pure string/regex matching — no external
+   * lookups, no DNS, no message body needed.
+   *
+   * @param headers    Header map with **lowercased** header names as keys and
+   *                   the raw header value as string (multi-valued headers may
+   *                   be joined with newlines).
+   * @param fromAddress The message's From value (e.g. "Name <a@b.com>"), used
+   *                   for the domain-mismatch checks.
+   */
+  checkHeaders(headers: Record<string, string>, fromAddress: string): HeaderRedFlag[] {
+    const flags: HeaderRedFlag[] = [];
+    const get = (name: string): string | undefined => {
+      const v = headers[name.toLowerCase()];
+      return typeof v === 'string' && v.trim() !== '' ? v.trim() : undefined;
+    };
+
+    // 1) X-Mailer / User-Agent — known bulk/mass mailer software.
+    const mailerHeader = get('x-mailer') ? 'X-Mailer' : get('user-agent') ? 'User-Agent' : undefined;
+    const mailer = get('x-mailer') || get('user-agent');
+    if (mailer && mailerHeader) {
+      const lower = mailer.toLowerCase();
+      const hit = BULK_MAILER_SIGNATURES.find(sig => lower.includes(sig));
+      if (hit) {
+        flags.push({
+          header: mailerHeader,
+          value: mailer,
+          reason: `Known bulk/mass-mail tool (${hit})`,
+          severity: 'medium',
+        });
+      }
+    }
+
+    // 2) Precedence: bulk/junk marker, or list without mailing-list headers.
+    const precedence = get('precedence');
+    if (precedence) {
+      const p = precedence.toLowerCase();
+      if (p === 'bulk' || p === 'junk') {
+        flags.push({
+          header: 'Precedence',
+          value: precedence,
+          reason: 'Mass-mail marker',
+          severity: 'low',
+        });
+      } else if (p === 'list' && !get('list-id') && !get('list-unsubscribe')) {
+        flags.push({
+          header: 'Precedence',
+          value: precedence,
+          reason: 'List precedence without mailing-list headers',
+          severity: 'low',
+        });
+      }
+    }
+
+    // 3) Authentication-Results — DMARC/SPF/DKIM failures.
+    const auth = get('authentication-results');
+    if (auth) {
+      const a = auth.toLowerCase();
+      const dmarc = a.match(/dmarc=(none|fail|permerror|temperror)/);
+      if (dmarc) {
+        const fail = dmarc[1] !== 'none';
+        flags.push({
+          header: 'Authentication-Results',
+          value: `dmarc=${dmarc[1]}`,
+          reason: fail ? 'DMARC did not pass' : 'No/absent DMARC alignment',
+          severity: fail ? 'high' : 'medium',
+        });
+      }
+      const spf = a.match(/spf=(fail|softfail)/);
+      if (spf) {
+        flags.push({
+          header: 'Authentication-Results',
+          value: `spf=${spf[1]}`,
+          reason: spf[1] === 'fail' ? 'SPF failed' : 'SPF softfail',
+          severity: spf[1] === 'fail' ? 'high' : 'medium',
+        });
+      }
+      if (/dkim=fail/.test(a)) {
+        flags.push({
+          header: 'Authentication-Results',
+          value: 'dkim=fail',
+          reason: 'DKIM signature failed',
+          severity: 'medium',
+        });
+      }
+    }
+
+    const fromDomain = fromAddress ? this.extractDomain(fromAddress) : null;
+
+    // 4) List-Unsubscribe — unsubscribe host unrelated to the sender domain.
+    const listUnsub = get('list-unsubscribe');
+    if (listUnsub && fromDomain) {
+      const hosts = this.extractHeaderHosts(listUnsub);
+      if (hosts.length > 0 && !hosts.some(h => this.domainsRelated(h, fromDomain))) {
+        flags.push({
+          header: 'List-Unsubscribe',
+          value: listUnsub.length > 200 ? `${listUnsub.slice(0, 200)}…` : listUnsub,
+          reason: `Unsubscribe host (${hosts.join(', ')}) unrelated to sender domain (${fromDomain})`,
+          severity: 'low',
+        });
+      }
+    }
+
+    // 5) Reply-To — domain differs from the From domain.
+    const replyTo = get('reply-to');
+    if (replyTo && fromDomain) {
+      const replyDomain = this.extractDomain(replyTo);
+      if (replyDomain && !this.domainsRelated(replyDomain, fromDomain)) {
+        flags.push({
+          header: 'Reply-To',
+          value: replyTo,
+          reason: `Reply-To domain (${replyDomain}) differs from From domain (${fromDomain})`,
+          severity: 'low',
+        });
+      }
+    }
+
+    return flags;
+  }
+
+  /**
+   * Two hostnames are considered "related" when they are equal or one is a
+   * subdomain of the other (e.g. `mail.firma.de` vs `firma.de`). Deterministic
+   * suffix comparison — deliberately simpler than a full public-suffix lookup,
+   * which keeps it dependency-free while catching the common ESP-vs-sender case.
+   */
+  private domainsRelated(a: string, b: string): boolean {
+    a = a.toLowerCase();
+    b = b.toLowerCase();
+    return a === b || a.endsWith(`.${b}`) || b.endsWith(`.${a}`);
+  }
+
+  /**
+   * Extract hostnames from a header value containing http(s) URLs and/or
+   * `mailto:` addresses (e.g. a List-Unsubscribe header). Ports and paths are
+   * stripped; results are lowercased.
+   */
+  private extractHeaderHosts(value: string): string[] {
+    const hosts: string[] = [];
+    const urlRe = /https?:\/\/([^/>\s,]+)/gi;
+    let m: RegExpExecArray | null;
+    while ((m = urlRe.exec(value)) !== null) {
+      hosts.push(m[1].toLowerCase().replace(/:\d+$/, ''));
+    }
+    const mailRe = /mailto:[^@>\s]+@([^>\s,?]+)/gi;
+    while ((m = mailRe.exec(value)) !== null) {
+      hosts.push(m[1].toLowerCase());
+    }
+    return hosts;
   }
 
   addSpamDomain(domain: string): void {

--- a/src/tools/spam-tools.ts
+++ b/src/tools/spam-tools.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ImapService } from '../services/imap-service.js';
-import { SpamService } from '../services/spam-service.js';
+import { SpamService, HeaderRedFlag } from '../services/spam-service.js';
 import { z } from 'zod';
 
 export function spamTools(
@@ -10,15 +10,16 @@ export function spamTools(
 ): void {
   // Check emails for spam
   server.registerTool('imap_check_spam', {
-    description: 'Check emails in a folder for spam/disposable email domains. Returns spam analysis and domain statistics.',
+    description: 'Check emails in a folder for spam. Combines sender-domain checks (known spam/disposable domains, suspicious patterns) with deterministic raw-header analysis: bulk-mailer X-Mailer/User-Agent signatures, Precedence: bulk, DMARC/SPF/DKIM failures in Authentication-Results, and List-Unsubscribe / Reply-To domains that do not match the sender. Header checks catch scam mail from fresh, unlisted domains that pass the domain check. Returns domain-based spam, a separate list of header-flagged mails, and domain statistics.',
     inputSchema: {
       accountId: z.string().describe('Account ID'),
       folder: z.string().default('INBOX').describe('Folder name'),
       limit: z.coerce.number().default(100).describe('Maximum number of emails to check'),
       from: z.string().optional().describe('Filter by sender (optional)'),
       since: z.string().optional().describe('Check emails since date (YYYY-MM-DD)'),
+      includeHeaderChecks: z.boolean().default(true).describe('Also run deterministic raw-header checks (X-Mailer bulk tools, Precedence: bulk, DMARC/SPF/DKIM failures, List-Unsubscribe/Reply-To domain mismatches) on top of the sender-domain check. Fetches message headers in one extra batch round-trip. Set false to skip header analysis and only check sender domains.'),
     }
-  }, async ({ accountId, folder, limit, from, since }) => {
+  }, async ({ accountId, folder, limit, from, since, includeHeaderChecks }) => {
     const criteria: any = {};
     if (from) criteria.from = from;
     if (since) criteria.since = new Date(since);
@@ -34,6 +35,34 @@ export function spamTools(
 
     const result = spamService.checkEmails(emailData);
 
+    // Header-based indicators — analyzed for every checked message, so scam
+    // mail from a fresh/unlisted domain (which passes the domain check) is
+    // still surfaced. One extra batch fetch for the raw headers.
+    const headerFlagsByUid = new Map<number, HeaderRedFlag[]>();
+    if (includeHeaderChecks && limitedMessages.length > 0) {
+      const headersByUid = await imapService.fetchHeadersForUids(
+        accountId,
+        folder,
+        limitedMessages.map(m => m.uid),
+      );
+      for (const m of limitedMessages) {
+        const h = headersByUid.get(m.uid);
+        if (!h) continue;
+        const flags = spamService.checkHeaders(h, m.from);
+        if (flags.length > 0) headerFlagsByUid.set(m.uid, flags);
+      }
+    }
+
+    const domainSpamUids = new Set(result.spam.map(s => (s as any).uid));
+    const headerFlagged = limitedMessages
+      .filter(m => headerFlagsByUid.has(m.uid) && !domainSpamUids.has(m.uid))
+      .map(m => ({
+        uid: m.uid,
+        from: m.from,
+        subject: m.subject,
+        headerRedFlags: headerFlagsByUid.get(m.uid),
+      }));
+
     return {
       content: [{
         type: 'text',
@@ -41,6 +70,7 @@ export function spamTools(
           totalChecked: limitedMessages.length,
           spamCount: result.spam.length,
           cleanCount: result.clean.length,
+          headerFlaggedCount: headerFlagged.length,
           spamEmails: result.spam.map(s => ({
             uid: (s as any).uid,
             from: s.email,
@@ -48,9 +78,11 @@ export function spamTools(
             domain: s.domain,
             reason: s.reason,
             confidence: s.confidence,
+            headerRedFlags: headerFlagsByUid.get((s as any).uid),
           })),
+          headerFlagged,
           topDomains: result.domainStats.slice(0, 20),
-          message: `Found ${result.spam.length} potential spam emails out of ${limitedMessages.length} checked`,
+          message: `Found ${result.spam.length} domain-based spam${includeHeaderChecks ? ` and ${headerFlagged.length} more with header red flags` : ''} out of ${limitedMessages.length} checked`,
         }, null, 2)
       }]
     };

--- a/tests/parse-raw-headers.test.ts
+++ b/tests/parse-raw-headers.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { parseRawHeaders } from '../src/services/imap-service.js';
+
+describe('parseRawHeaders', () => {
+  it('parses simple headers with lowercased keys', () => {
+    const h = parseRawHeaders('From: a@b.com\r\nSubject: Hello\r\n');
+    expect(h.from).toBe('a@b.com');
+    expect(h.subject).toBe('Hello');
+  });
+
+  it('accepts a Buffer as input', () => {
+    const h = parseRawHeaders(Buffer.from('X-Mailer: Sendy\r\n', 'utf8'));
+    expect(h['x-mailer']).toBe('Sendy');
+  });
+
+  it('unfolds continuation lines', () => {
+    const raw = 'Authentication-Results: mx.example.de;\r\n dmarc=none;\r\n\tspf=softfail\r\n';
+    expect(parseRawHeaders(raw)['authentication-results']).toBe(
+      'mx.example.de; dmarc=none; spf=softfail',
+    );
+  });
+
+  it('joins repeated headers with newlines', () => {
+    const raw = 'Received: from a\r\nReceived: from b\r\n';
+    expect(parseRawHeaders(raw).received).toBe('from a\nfrom b');
+  });
+
+  it('handles LF-only line endings and ignores malformed lines', () => {
+    const h = parseRawHeaders('From: a@b.com\ngarbage-without-colon\nSubject: Hi\n');
+    expect(h.from).toBe('a@b.com');
+    expect(h.subject).toBe('Hi');
+    expect(Object.keys(h)).toHaveLength(2);
+  });
+
+  it('returns an empty object for empty input', () => {
+    expect(parseRawHeaders('')).toEqual({});
+  });
+});

--- a/tests/spam-service.test.ts
+++ b/tests/spam-service.test.ts
@@ -173,6 +173,124 @@ describe('SpamService', () => {
     });
   });
 
+  describe('checkHeaders', () => {
+    const FROM = 'Info <info@example.de>';
+
+    it('returns no flags for clean, authenticated headers', () => {
+      const flags = spamService.checkHeaders(
+        {
+          'authentication-results': 'mx.example.de; dmarc=pass; spf=pass; dkim=pass',
+          'x-mailer': 'Apple Mail (2.3696.120.41.1.1)',
+        },
+        FROM,
+      );
+      expect(flags).toEqual([]);
+    });
+
+    it('flags a known bulk mailer in X-Mailer', () => {
+      const flags = spamService.checkHeaders({ 'x-mailer': 'Sendy (https://sendy.co)' }, FROM);
+      expect(flags).toHaveLength(1);
+      expect(flags[0].header).toBe('X-Mailer');
+      expect(flags[0].reason).toContain('sendy');
+    });
+
+    it('flags PHPMailer in X-Mailer (case-insensitive)', () => {
+      const flags = spamService.checkHeaders({ 'x-mailer': 'PHPMailer 6.8.0' }, FROM);
+      expect(flags.some(f => f.header === 'X-Mailer')).toBe(true);
+    });
+
+    it('does not flag a legitimate mail client User-Agent', () => {
+      const flags = spamService.checkHeaders({ 'user-agent': 'Mozilla Thunderbird' }, FROM);
+      expect(flags).toEqual([]);
+    });
+
+    it('flags Precedence: bulk', () => {
+      const flags = spamService.checkHeaders({ precedence: 'bulk' }, FROM);
+      expect(flags).toHaveLength(1);
+      expect(flags[0].header).toBe('Precedence');
+    });
+
+    it('flags Precedence: list only when mailing-list headers are absent', () => {
+      expect(spamService.checkHeaders({ precedence: 'list' }, FROM)).toHaveLength(1);
+      expect(
+        spamService.checkHeaders(
+          { precedence: 'list', 'list-unsubscribe': '<https://example.de/unsub>' },
+          FROM,
+        ),
+      ).toEqual([]);
+    });
+
+    it('flags DMARC none as medium and DMARC fail as high', () => {
+      const none = spamService.checkHeaders({ 'authentication-results': 'x; dmarc=none' }, FROM);
+      expect(none[0]).toMatchObject({ value: 'dmarc=none', severity: 'medium' });
+
+      const fail = spamService.checkHeaders({ 'authentication-results': 'x; dmarc=fail' }, FROM);
+      expect(fail[0]).toMatchObject({ value: 'dmarc=fail', severity: 'high' });
+    });
+
+    it('flags SPF fail (high) and softfail (medium)', () => {
+      const fail = spamService.checkHeaders({ 'authentication-results': 'x; spf=fail' }, FROM);
+      expect(fail.some(f => f.value === 'spf=fail' && f.severity === 'high')).toBe(true);
+
+      const soft = spamService.checkHeaders({ 'authentication-results': 'x; spf=softfail' }, FROM);
+      expect(soft.some(f => f.value === 'spf=softfail' && f.severity === 'medium')).toBe(true);
+    });
+
+    it('flags a List-Unsubscribe host unrelated to the sender domain', () => {
+      const flags = spamService.checkHeaders(
+        { 'list-unsubscribe': '<https://track.spammer-cdn.com/u/abc>, <mailto:off@spammer-cdn.com>' },
+        FROM,
+      );
+      expect(flags.some(f => f.header === 'List-Unsubscribe')).toBe(true);
+    });
+
+    it('does not flag a List-Unsubscribe host on a sender subdomain', () => {
+      const flags = spamService.checkHeaders(
+        { 'list-unsubscribe': '<https://mail.example.de/unsubscribe?id=1>' },
+        FROM,
+      );
+      expect(flags).toEqual([]);
+    });
+
+    it('flags a Reply-To domain that differs from the From domain', () => {
+      const flags = spamService.checkHeaders({ 'reply-to': 'noreply@totally-different.ru' }, FROM);
+      expect(flags).toHaveLength(1);
+      expect(flags[0].header).toBe('Reply-To');
+    });
+
+    it('does not flag a Reply-To on the same or a subdomain of the sender', () => {
+      expect(spamService.checkHeaders({ 'reply-to': 'support@example.de' }, FROM)).toEqual([]);
+      expect(spamService.checkHeaders({ 'reply-to': 'support@help.example.de' }, FROM)).toEqual([]);
+    });
+
+    it('surfaces multiple red flags for a scam mail that passes the domain check (issue #115)', () => {
+      // Fresh, unlisted sender domain — checkEmail would return isSpam=false.
+      expect(spamService.checkEmail('info@fresh-unlisted-domain.de').isSpam).toBe(false);
+
+      const flags = spamService.checkHeaders(
+        {
+          'x-mailer': 'Sendy',
+          precedence: 'Bulk',
+          'authentication-results': 'mx.provider.de; dmarc=none; spf=softfail',
+          'list-unsubscribe': '<https://unsub.thirdparty-tracker.com/x>',
+        },
+        'Info <info@fresh-unlisted-domain.de>',
+      );
+
+      const headers = flags.map(f => f.header);
+      expect(headers).toContain('X-Mailer');
+      expect(headers).toContain('Precedence');
+      expect(headers).toContain('Authentication-Results');
+      expect(headers).toContain('List-Unsubscribe');
+      expect(flags.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('ignores mismatch checks when the From address has no extractable domain', () => {
+      const flags = spamService.checkHeaders({ 'reply-to': 'x@other.com' }, 'not-an-email');
+      expect(flags).toEqual([]);
+    });
+  });
+
   describe('getKnownSpamDomains', () => {
     it('should return known spam domains', () => {
       const domains = spamService.getKnownSpamDomains();


### PR DESCRIPTION
Implements #115. Adds deterministic, dependency-free **raw-header analysis** to `imap_check_spam` on top of the existing sender-domain check — so scam mail from a **fresh, unlisted domain** (which passes the domain check) is still surfaced. Fully additive and backwards-compatible.

## What it checks (`SpamService.checkHeaders`)

Pure string/regex matching, no external lookups, no DNS, no message body:

- **X-Mailer / User-Agent** — known bulk/mass-mailer signatures (Sendy, PHPMailer, PHPList, PowerMTA, …). Legitimate clients (Thunderbird, Apple Mail) are not flagged.
- **Precedence** — `bulk`/`junk` markers; `list` only when no `List-Id`/`List-Unsubscribe` is present.
- **Authentication-Results** — `dmarc=none` (medium) / `dmarc=fail` (high), `spf=softfail` (medium) / `spf=fail` (high), `dkim=fail` (medium).
- **List-Unsubscribe** — unsubscribe host unrelated to the sender domain.
- **Reply-To** — domain differs from the From domain.

Each finding carries `{ header, value, reason, severity }`. Domain relatedness uses a deterministic subdomain-suffix comparison (`mail.firma.de` ↔ `firma.de` counts as related), which keeps it dependency-free while avoiding the common ESP-subdomain false positive.

## Wiring

- **`ImapService.fetchHeadersForUids`** — one batched header-only fetch for all checked UIDs (no body parse), plus an exported **`parseRawHeaders`** helper that unfolds continuation lines and joins repeated headers.
- **`imap_check_spam`** — new optional **`includeHeaderChecks`** (default `true`). Enriches each `spamEmails` entry with `headerRedFlags` and adds a top-level **`headerFlagged`** list for mails flagged by headers but *not* by domain (plus `headerFlaggedCount`). Existing fields are unchanged; set `includeHeaderChecks=false` to skip the extra fetch and get the old domain-only behaviour.

Example (the issue's scam mail): fresh domain → `spamEmails` empty, but it lands in `headerFlagged` with X-Mailer=Sendy, Precedence=bulk, dmarc=none, and an unrelated unsubscribe host.

## Tests

18 new cases:
- `tests/spam-service.test.ts` — a `checkHeaders` block covering every red flag, the negative cases (authenticated mail, legit client, sender-subdomain unsubscribe/reply-to), and the issue's multi-flag scam example.
- `tests/parse-raw-headers.test.ts` — folding, repeated headers, Buffer input, LF-only, malformed lines, empty input.

## Verification

- `npm run build` ✅
- `npm test` → **220 pass**; the single `email-tools-pdf-extract` failure is **pre-existing on `main`** (unrelated pdf-parse issue, confirmed via stash).
- `tsc --noEmit --skipLibCheck` → only the two **pre-existing** `PDFParse` errors (present on clean `main`, unrelated to this PR).

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)