### PR TITLE
fix(security): scrub wizard creds, block path traversal, guard bulk-delete, lock down store

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,9 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - chunkSize: Emails to delete per batch (default: 50)
   - dryRun: Preview what would be deleted without deleting (default: false)
   ```
+  At least one concrete criterion (`from`, `to`, `subject`, `before`, or `since`)
+  is required — a call with no criteria is refused, so it can never match and
+  delete an entire folder.
 
 - **imap_send_email**: Send a new email
   ```
@@ -536,6 +539,11 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
 - Credentials are encrypted using AES-256-CBC encryption
 - Encryption keys are stored separately in `~/.imap-mcp/.key`
 - Account configurations are stored in `~/.imap-mcp/accounts.json`
+- The store directory, `.key`, and `accounts.json` are written owner-only
+  (`0700`/`0600`) so other local users cannot read the key or the credentials
+- The web setup wizard's HTTP API never returns stored passwords to the browser
+- Downloaded attachments are confined to the downloads directory; sender-supplied
+  filenames cannot write outside it
 - Never commit or share your encryption key or account configurations
 
 ## Development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,9 @@ control**.
   account with this project.
 - **Credential storage.** IMAP/SMTP credentials are stored encrypted with
   **AES-256-CBC** in `~/.imap-mcp/accounts.json`. The encryption key is generated
-  locally and kept at `~/.imap-mcp/.key`. Protect these files with your OS user
-  permissions; anyone who can read both files can read your credentials.
+  locally and kept at `~/.imap-mcp/.key`. The store directory and both files are
+  written owner-only (`0700`/`0600`) so other local users cannot read them;
+  anyone who can read both files can read your credentials.
 - **No telemetry.** The server collects no analytics, usage data, or crash
   reports.
 - **No third-party data sharing.** The only outbound network connections are to
@@ -31,18 +32,25 @@ control**.
 - Prefer least-privilege accounts/folders when possible.
 - Be deliberate with destructive tools (`imap_delete_email`,
   `imap_bulk_delete`, `imap_bulk_delete_by_search`) — use the `dryRun` option to
-  preview criteria-based deletions first.
+  preview criteria-based deletions first. `imap_bulk_delete_by_search` requires
+  at least one concrete criterion and refuses an empty criteria set, so it can
+  never wipe a whole folder by accident.
 
 ## Reporting a vulnerability (responsible disclosure)
 
 If you discover a security issue, please report it **privately** — do not open a
 public issue with exploit details.
 
-- Use GitHub's **[Report a vulnerability](https://github.com/nikolausm/imap-mcp-server/security/advisories/new)**
-  (Security → Advisories) to open a private advisory, **or**
-- Contact the maintainer via the email on the
-  [GitHub profile](https://github.com/nikolausm).
+- **Preferred:** use GitHub's **[Report a vulnerability](https://github.com/nikolausm/imap-mcp-server/security/advisories/new)**
+  (Security → Advisories) to open a private advisory. Private vulnerability
+  reporting is enabled on this repository, so this form works and routes the
+  report only to the maintainer.
+- **If that form is unavailable to you:** open a regular GitHub issue that says
+  only that you have a security report and asks for a private contact channel —
+  **without** any details, reproduction steps, or exploit information. The
+  maintainer will follow up privately.
 
-Please include reproduction steps and affected versions. We aim to acknowledge
-reports promptly, investigate, and ship a fix with a coordinated disclosure once
-a patch is available. Thank you for helping keep users safe.
+Please include reproduction steps and affected versions in the private report.
+We aim to acknowledge reports promptly, investigate, and ship a fix with a
+coordinated disclosure once a patch is available. Thank you for helping keep
+users safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,8 +45,11 @@ public issue with exploit details.
   (Security → Advisories) to open a private advisory. Private vulnerability
   reporting is enabled on this repository, so this form works and routes the
   report only to the maintainer.
-- **If that form is unavailable to you:** open a regular GitHub issue that says
-  only that you have a security report and asks for a private contact channel —
+- **By email:** write to **security.imap-mcp-server@minicon.eu**. Please do not
+  include exploit details in an unencrypted first email if you can avoid it —
+  a heads-up plus a request for a secure channel is enough to get started.
+- **If neither is available to you:** open a regular GitHub issue that says only
+  that you have a security report and asks for a private contact channel —
   **without** any details, reproduction steps, or exploit information. The
   maintainer will follow up privately.
 

--- a/src/services/account-manager.ts
+++ b/src/services/account-manager.ts
@@ -207,10 +207,42 @@ export class AccountManager {
 
   private async saveAccounts(): Promise<void> {
     const dir = path.dirname(this.configPath);
-    await fs.mkdir(dir, { recursive: true });
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
 
     const accounts = Array.from(this.accounts.values());
-    await fs.writeFile(this.configPath, JSON.stringify(accounts, null, 2));
+    await fs.writeFile(this.configPath, JSON.stringify(accounts, null, 2), { mode: 0o600 });
+
+    await this.enforceStorePermissions();
+  }
+
+  /**
+   * Defence in depth for the credential store. `~/.imap-mcp/` holds the raw
+   * AES-256 key and the (encrypted) accounts, so anyone able to read the key
+   * plus the store can recover every password. The `mode` options above only
+   * apply when a file is *created*; a store written before this hardening — or
+   * under a permissive umask — could still be world-readable. Re-assert
+   * owner-only permissions on the directory, the accounts file, and the key.
+   * Best effort: silently ignored on platforms without POSIX modes (Windows)
+   * or when a path does not exist yet.
+   */
+  private async enforceStorePermissions(): Promise<void> {
+    if (process.platform === 'win32') return;
+
+    const dir = path.dirname(this.configPath);
+    const keyPath = path.join(dir, '.key');
+    const targets: Array<[string, number]> = [
+      [dir, 0o700],
+      [this.configPath, 0o600],
+      [keyPath, 0o600],
+    ];
+
+    for (const [target, mode] of targets) {
+      try {
+        await fs.chmod(target, mode);
+      } catch {
+        // best effort — path may not exist yet, or fs is stubbed in tests
+      }
+    }
   }
 
   private getOrCreateEncryptionKey(): string {
@@ -220,8 +252,10 @@ export class AccountManager {
       return readFileSync(keyPath, 'utf-8');
     } catch {
       const key = crypto.randomBytes(32).toString('hex');
-      mkdirSync(path.dirname(keyPath), { recursive: true });
-      writeFileSync(keyPath, key);
+      // Owner-only from the moment of creation: the key alone can decrypt every
+      // stored credential (see enforceStorePermissions).
+      mkdirSync(path.dirname(keyPath), { recursive: true, mode: 0o700 });
+      writeFileSync(keyPath, key, { mode: 0o600 });
       return key;
     }
   }

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -346,7 +346,10 @@ export function emailTools(
         const path = await import('path');
         const downloadDir = savePath ? path.dirname(savePath) : DOWNLOAD_DIR;
         fs.mkdirSync(downloadDir, { recursive: true });
-        const targetPath = savePath || path.join(DOWNLOAD_DIR, resolvedFilename);
+        // resolvedFilename comes from the (sender-controlled) MIME headers, so it
+        // may contain path-traversal segments like "../../". Confine the default
+        // save to DOWNLOAD_DIR via basename; an explicit savePath is caller-chosen.
+        const targetPath = savePath || path.join(DOWNLOAD_DIR, path.basename(resolvedFilename));
         fs.writeFileSync(targetPath, content);
 
         return {
@@ -374,7 +377,9 @@ export function emailTools(
     const path = await import('path');
     const downloadDir = savePath ? path.dirname(savePath) : DOWNLOAD_DIR;
     fs.mkdirSync(downloadDir, { recursive: true });
-    const targetPath = savePath || path.join(DOWNLOAD_DIR, resolvedFilename);
+    // Confine the default save to DOWNLOAD_DIR: resolvedFilename is sender-
+    // controlled and may contain "../" traversal (savePath is caller-chosen).
+    const targetPath = savePath || path.join(DOWNLOAD_DIR, path.basename(resolvedFilename));
     fs.writeFileSync(targetPath, content);
 
     return {
@@ -693,7 +698,7 @@ export function emailTools(
 
   // Bulk delete by search criteria tool
   server.registerTool('imap_bulk_delete_by_search', {
-    description: 'Search for emails matching criteria and delete them all. Useful for cleaning up spam or unwanted emails.',
+    description: 'Search for emails matching criteria and delete them all. Useful for cleaning up spam or unwanted emails. At least one concrete criterion (from, to, subject, before, or since) is REQUIRED — a call with no criteria is refused so it can never wipe an entire folder. Supports dryRun to preview matches first.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder name'),
@@ -713,6 +718,24 @@ export function emailTools(
     if (subject) criteria.subject = subject;
     if (before) criteria.before = parseDateOnly(before);
     if (since) criteria.since = parseDateOnly(since);
+
+    // Guard: never run with an empty criteria set. imapflow compiles an empty
+    // search to IMAP "SEARCH ALL", which would match — and then delete — every
+    // message in the folder. Require at least one concrete criterion (this also
+    // covers dryRun, so a preview can never imply a whole-folder wipe).
+    if (Object.keys(criteria).length === 0) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            found: 0,
+            deleted: 0,
+            error: 'Refusing to bulk-delete without criteria. Specify at least one of from, to, subject, before, or since — an empty criteria set would match and delete the entire folder.',
+          }, null, 2)
+        }]
+      };
+    }
 
     // First search for matching emails
     const messages = await imapService.searchEmails(accountId, folder, criteria);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -13,20 +13,42 @@ import { ImapAccount } from '../types/index.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Strip credentials before an account crosses the wizard's HTTP boundary. The
+// API is unauthenticated and CORS-open, so any local page could otherwise read
+// plaintext IMAP/SMTP passwords out of a response. Returns a shallow copy with
+// `password` and `smtp.password` removed.
+function stripAccountSecrets<T extends Record<string, any>>(account: T): Omit<T, 'password'> {
+  const { password: _password, ...rest } = account;
+  const safe: Record<string, any> = { ...rest };
+  if (safe.smtp && typeof safe.smtp === 'object' && 'password' in safe.smtp) {
+    safe.smtp = { ...safe.smtp };
+    delete safe.smtp.password;
+  }
+  return safe as Omit<T, 'password'>;
+}
+
 export class WebUIServer {
   private app: express.Application;
   private accountManager: AccountManager;
   private imapService: ImapService;
   private port: number;
 
-  constructor(port: number = 3000) {
+  constructor(
+    port: number = 3000,
+    deps: { accountManager?: AccountManager; imapService?: ImapService } = {},
+  ) {
     this.app = express();
     this.port = port;
-    this.accountManager = new AccountManager();
-    this.imapService = new ImapService();
-    
+    this.accountManager = deps.accountManager ?? new AccountManager();
+    this.imapService = deps.imapService ?? new ImapService();
+
     this.setupMiddleware();
     this.setupRoutes();
+  }
+
+  /** The configured Express application. Exposed for tests. */
+  getApp(): express.Application {
+    return this.app;
   }
 
   private setupMiddleware(): void {
@@ -58,7 +80,8 @@ export class WebUIServer {
     this.app.get('/api/accounts', (req, res) => {
       try {
         const accounts = this.accountManager.getAllAccounts();
-        res.json(accounts);
+        // Never send credentials to the client — see stripAccountSecrets.
+        res.json(accounts.map(stripAccountSecrets));
       } catch (error) {
         res.status(500).json({ error: 'Failed to fetch accounts' });
       }
@@ -191,17 +214,8 @@ export class WebUIServer {
         if (!account) {
           res.status(404).json({ success: false, error: 'Account not found' });
         } else {
-          // Don't send passwords to client
-          const { password, ...accountWithoutPassword } = account;
-          const safeAccount = { ...accountWithoutPassword };
-          
-          // Remove SMTP password if present
-          if (safeAccount.smtp?.password) {
-            safeAccount.smtp = { ...safeAccount.smtp };
-            delete safeAccount.smtp.password;
-          }
-          
-          res.json({ success: true, account: safeAccount });
+          // Don't send passwords to client — see stripAccountSecrets.
+          res.json({ success: true, account: stripAccountSecrets(account) });
         }
       } catch (error) {
         res.status(400).json({ 

--- a/tests/account-manager-permissions.test.ts
+++ b/tests/account-manager-permissions.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fsp, statSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Real filesystem test (no fs mock): the credential store holds the raw AES key
+// and the encrypted accounts, so both — and their directory — must be readable
+// only by the owner. POSIX-only; Windows has no comparable mode bits.
+const runOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
+runOnPosix('AccountManager credential-store permissions', () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+
+  beforeEach(async () => {
+    prevHome = process.env.HOME;
+    tmpHome = await fsp.mkdtemp(path.join(os.tmpdir(), 'imap-mcp-perms-'));
+    // AccountManager derives ~/.imap-mcp from os.homedir(), which honours $HOME.
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    await fsp.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('writes .key, accounts.json and their directory owner-only', async () => {
+    const { AccountManager } = await import('../src/services/account-manager.js');
+    const manager = new AccountManager();
+
+    await manager.addAccount({
+      name: 'Test',
+      host: 'imap.test.com',
+      port: 993,
+      user: 'user@test.com',
+      password: 'topsecret',
+      tls: true,
+    });
+
+    const dir = path.join(tmpHome, '.imap-mcp');
+    const mode = (p: string) => statSync(p).mode & 0o777;
+
+    expect(mode(path.join(dir, '.key'))).toBe(0o600);
+    expect(mode(path.join(dir, 'accounts.json'))).toBe(0o600);
+    expect(mode(dir)).toBe(0o700);
+  });
+});

--- a/tests/email-tools-attachment-path-traversal.test.ts
+++ b/tests/email-tools-attachment-path-traversal.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { promises as fsp } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// The download dir is read into a module-level const when email-tools is
+// imported, so point it at a throwaway temp dir BEFORE the import below.
+const TMP_DOWNLOAD_DIR = path.join(os.tmpdir(), `imap-attach-traversal-${process.pid}`);
+process.env.IMAP_DOWNLOAD_DIR = TMP_DOWNLOAD_DIR;
+
+const { emailTools } = await import('../src/tools/email-tools.js');
+
+let downloadHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_download_attachment') {
+      downloadHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  getAttachmentContent: vi.fn(),
+};
+const mockAccountManager = { resolveAccountId: (id: string) => id ?? 'acc1' };
+const mockSmtpService = {};
+
+describe('imap_download_attachment — path traversal via sender-controlled filename', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emailTools(
+      mockServer as any,
+      mockImapService as any,
+      mockAccountManager as any,
+      mockSmtpService as any,
+    );
+  });
+
+  afterAll(async () => {
+    await fsp.rm(TMP_DOWNLOAD_DIR, { recursive: true, force: true });
+  });
+
+  it('confines a "../" attachment filename to the download directory', async () => {
+    // A malicious sender names the attachment to climb out of the download dir.
+    mockImapService.getAttachmentContent.mockResolvedValueOnce({
+      content: Buffer.from('pwned'),
+      contentType: 'application/octet-stream',
+      filename: '../../../../../../tmp/imap-mcp-escape.txt',
+    });
+
+    const result = await downloadHandler({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      uid: 1,
+      filename: '../../../../../../tmp/imap-mcp-escape.txt',
+      extractText: false,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    const savedTo = path.resolve(parsed.path);
+    const downloadRoot = path.resolve(TMP_DOWNLOAD_DIR);
+
+    // The file must land INSIDE the download dir, with the traversal stripped.
+    expect(savedTo.startsWith(downloadRoot + path.sep)).toBe(true);
+    expect(path.basename(savedTo)).toBe('imap-mcp-escape.txt');
+    expect(path.dirname(savedTo)).toBe(downloadRoot);
+  });
+});

--- a/tests/email-tools-bulk-delete-guard.test.ts
+++ b/tests/email-tools-bulk-delete-guard.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emailTools } from '../src/tools/email-tools.js';
+
+// Capture the handler registered for imap_bulk_delete_by_search
+let bulkDeleteBySearchHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_bulk_delete_by_search') {
+      bulkDeleteBySearchHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  searchEmails: vi.fn(),
+  bulkDelete: vi.fn(),
+};
+
+const mockAccountManager = { resolveAccountId: (id: string) => id ?? 'acc1' };
+const mockSmtpService = {};
+
+describe('imap_bulk_delete_by_search — empty-criteria guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emailTools(
+      mockServer as any,
+      mockImapService as any,
+      mockAccountManager as any,
+      mockSmtpService as any,
+    );
+  });
+
+  it('refuses to run when no criteria are given, and never touches the mailbox', async () => {
+    const result = await bulkDeleteBySearchHandler({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      chunkSize: 50,
+      dryRun: false,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/criteria/i);
+    // The whole point: no search, and above all no delete, may be issued.
+    expect(mockImapService.searchEmails).not.toHaveBeenCalled();
+    expect(mockImapService.bulkDelete).not.toHaveBeenCalled();
+  });
+
+  it('also refuses an empty-criteria dryRun (a preview must not imply a full wipe)', async () => {
+    const result = await bulkDeleteBySearchHandler({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      chunkSize: 50,
+      dryRun: true,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(false);
+    expect(mockImapService.searchEmails).not.toHaveBeenCalled();
+  });
+
+  it('still runs when a concrete criterion is supplied', async () => {
+    mockImapService.searchEmails.mockResolvedValueOnce([{ uid: 1, from: 'spam@x.com', subject: 'x', date: new Date() }]);
+    mockImapService.bulkDelete.mockResolvedValueOnce({ deleted: 1, failed: 0, errors: [] });
+
+    const result = await bulkDeleteBySearchHandler({
+      accountId: 'acc1',
+      folder: 'INBOX',
+      from: 'spam@x.com',
+      chunkSize: 50,
+      dryRun: false,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.success).toBe(true);
+    expect(parsed.deleted).toBe(1);
+    expect(mockImapService.searchEmails).toHaveBeenCalledOnce();
+    expect(mockImapService.bulkDelete).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/web-server-accounts.test.ts
+++ b/tests/web-server-accounts.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { WebUIServer } from '../src/web/server.js';
+
+// getAllAccounts() returns DECRYPTED credentials by design (the manager's job).
+// The wizard's HTTP API is unauthenticated and CORS-open, so the API layer must
+// never let those credentials cross the wire. Inject a fake manager holding
+// obvious secrets and assert the /api/accounts response is scrubbed.
+const SECRET = 'imap-plaintext-secret';
+const SMTP_SECRET = 'smtp-plaintext-secret';
+
+const fakeAccountManager = {
+  getAllAccounts: () => [
+    {
+      id: 'a1',
+      name: 'Work',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: SECRET,
+      tls: true,
+      smtp: { host: 'smtp.example.com', port: 587, secure: false, password: SMTP_SECRET },
+    },
+  ],
+  getAccount: (id: string) =>
+    id === 'a1'
+      ? {
+          id: 'a1',
+          name: 'Work',
+          host: 'imap.example.com',
+          port: 993,
+          user: 'user@example.com',
+          password: SECRET,
+          tls: true,
+          smtp: { host: 'smtp.example.com', port: 587, secure: false, password: SMTP_SECRET },
+        }
+      : undefined,
+};
+
+let httpServer: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const wizard = new WebUIServer(0, {
+    accountManager: fakeAccountManager as any,
+    imapService: {} as any,
+  });
+  await new Promise<void>((resolve) => {
+    httpServer = wizard.getApp().listen(0, () => resolve());
+  });
+  const { port } = httpServer.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  httpServer?.close();
+});
+
+describe('Web wizard credential exposure', () => {
+  it('GET /api/accounts never returns passwords', async () => {
+    const res = await fetch(`${baseUrl}/api/accounts`);
+    expect(res.ok).toBe(true);
+    const raw = await res.text();
+
+    // Belt: the plaintext secrets must not appear anywhere in the payload.
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain(SMTP_SECRET);
+
+    // Braces: the fields must be absent, and the rest of the account intact.
+    const accounts = JSON.parse(raw);
+    expect(Array.isArray(accounts)).toBe(true);
+    expect(accounts[0].password).toBeUndefined();
+    expect(accounts[0].smtp?.password).toBeUndefined();
+    expect(accounts[0].user).toBe('user@example.com');
+    expect(accounts[0].smtp?.host).toBe('smtp.example.com');
+  });
+
+  it('GET /api/accounts/:id also stays password-free', async () => {
+    const res = await fetch(`${baseUrl}/api/accounts/a1`);
+    const raw = await res.text();
+    expect(raw).not.toContain(SECRET);
+    expect(raw).not.toContain(SMTP_SECRET);
+    const body = JSON.parse(raw);
+    expect(body.account.password).toBeUndefined();
+    expect(body.account.smtp?.password).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Independently reproduced and fixed four issues surfaced by a security audit of `main` (`db83af5`). Each fix ships a regression test that **fails on main and passes with the fix**; full suite is green (249 tests) and the build is clean.

## Fixes

| # | Issue | Fix | Test |
|---|-------|-----|------|
| 1 | Web setup wizard `GET /api/accounts` returned decrypted IMAP/SMTP passwords | Scrub credentials at the HTTP boundary (`stripAccountSecrets`) on the list + single routes; DI for testability | `tests/web-server-accounts.test.ts` |
| 2 | `imap_download_attachment` wrote the sender-controlled MIME filename verbatim → `../` traversal out of the downloads dir | Confine the default save via `path.basename` | `tests/email-tools-attachment-path-traversal.test.ts` |
| 3 | `imap_bulk_delete_by_search` with no criteria compiled to IMAP `SEARCH ALL` → whole-folder wipe | Refuse an empty criteria set (dryRun included) | `tests/email-tools-bulk-delete-guard.test.ts` |
| 4 | `~/.imap-mcp/.key` and `accounts.json` world-readable (`0644`) | Create `0600` under a `0700` dir + re-assert perms on save for existing installs | `tests/account-manager-permissions.test.ts` |

## Docs / process
- `README.md` + `SECURITY.md` updated to match the new behavior.
- Private vulnerability reporting has been **enabled** on the repo so the advisory channel actually works; a dedicated `security.imap-mcp-server@minicon.eu` contact was added, replacing the dead profile-email pointer.

No public exploit details beyond what is necessary to review the fix. Reported privately by an external researcher; fixes written in-house.

🤖 Generated with [Claude Code](https://claude.com/claude-code)