### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imap-mcp-server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A powerful Model Context Protocol (MCP) server for IMAP email integration with Claude",
   "mcpName": "io.github.nikolausm/imap-mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/nikolausm/imap-mcp-server",
     "source": "github"
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "imap-mcp-server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Patch release shipping the security audit fixes merged in #120 to npm.

- Version bump only: `package.json`, `server.json` (top-level + `packages[0]`), and `package-lock.json` — no dependency-tree changes (the `@emnapi` Linux entries are left intact, so `npm ci` stays in sync).
- Build + full suite green locally (250 tests).

After merge, tag `v1.5.1` triggers the release workflow (npm Trusted Publishing + MCP Registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)