### PR TITLE
fix(security): scrub POST/PUT account routes + loopback-only guard

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -52,9 +52,54 @@ export class WebUIServer {
   }
 
   private setupMiddleware(): void {
+    // The setup wizard is unauthenticated and CORS-open, so it must never be
+    // reachable by anything other than the local user's own browser. Reject
+    // any request whose Host is not a loopback name (blocks DNS-rebinding, where
+    // a malicious site points its own domain at 127.0.0.1) and any cross-origin
+    // browser request (Origin set to a non-loopback origin). Together with
+    // stripAccountSecrets this closes the "any open page can read/modify the
+    // local accounts API" vector.
+    this.app.use(this.loopbackOnly());
     this.app.use(cors());
     this.app.use(bodyParser.json());
     this.app.use(express.static(this.resolvePublicDir()));
+  }
+
+  private static isLoopbackName(name: string): boolean {
+    const n = name.toLowerCase();
+    return n === 'localhost' || n === '127.0.0.1' || n === '::1';
+  }
+
+  // Guard: allow only loopback Host + (when present) loopback Origin. Non-browser
+  // clients (curl, tests) send no Origin and are allowed if the Host is loopback.
+  private loopbackOnly(): express.RequestHandler {
+    const hostname = (hostHeader: string): string =>
+      hostHeader.replace(/:\d+$/, '').replace(/^\[|\]$/g, '');
+
+    return (req, res, next) => {
+      const host = req.headers.host;
+      if (!host || !WebUIServer.isLoopbackName(hostname(host))) {
+        res.status(403).json({ error: 'Forbidden: the setup API is reachable on loopback only.' });
+        return;
+      }
+
+      const origin = req.headers.origin;
+      if (origin) {
+        let originHost: string;
+        try {
+          originHost = new URL(origin).hostname;
+        } catch {
+          res.status(403).json({ error: 'Forbidden: invalid Origin.' });
+          return;
+        }
+        if (!WebUIServer.isLoopbackName(originHost)) {
+          res.status(403).json({ error: 'Forbidden: cross-origin requests are not allowed.' });
+          return;
+        }
+      }
+
+      next();
+    };
   }
 
   // The bundled entrypoint may live at dist/web/server.js (npm run web) or be
@@ -116,8 +161,9 @@ export class WebUIServer {
           ...(imapUsername ? { email } : {}),
           smtp: smtp || undefined,
         });
-        
-        res.json({ success: true, account });
+
+        // addAccount returns the plaintext password back; never echo it.
+        res.json({ success: true, account: stripAccountSecrets(account) });
       } catch (error) {
         res.status(400).json({ 
           success: false, 
@@ -197,8 +243,11 @@ export class WebUIServer {
         if (smtp !== undefined) updates.smtp = smtp;
         if (saveToSent !== undefined) updates.saveToSent = saveToSent;
         
+        // updateAccount returns a DECRYPTED account (plaintext IMAP + SMTP
+        // passwords). A no-op update (e.g. a rename with no password supplied)
+        // would otherwise hand every stored secret back over the wire — strip.
         const account = await this.accountManager.updateAccount(req.params.id, updates);
-        res.json({ success: true, account });
+        res.json({ success: true, account: stripAccountSecrets(account) });
       } catch (error) {
         res.status(400).json({ 
           success: false, 

--- a/tests/web-server-hardening.test.ts
+++ b/tests/web-server-hardening.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import type { Server } from 'http';
+import { WebUIServer } from '../src/web/server.js';
+
+// Reproduces the gap Bjoern reported after the first fix: GET routes were
+// scrubbed, but POST/PUT still returned account objects with plaintext
+// passwords, and the API had no loopback/cross-origin guard.
+
+const IMAP_SECRET = 'imap-plaintext-secret';
+const SMTP_SECRET = 'smtp-plaintext-secret';
+
+const decryptedAccount = (over: Record<string, any> = {}) => ({
+  id: 'a1',
+  name: 'Work',
+  host: 'imap.example.com',
+  port: 993,
+  user: 'user@example.com',
+  password: IMAP_SECRET,
+  tls: true,
+  smtp: { host: 'smtp.example.com', port: 587, secure: false, password: SMTP_SECRET },
+  ...over,
+});
+
+const fakeAccountManager = {
+  getAllAccounts: () => [decryptedAccount()],
+  getAccount: (id: string) => (id === 'a1' ? decryptedAccount() : undefined),
+  // Mirrors the real AccountManager: returns a DECRYPTED account.
+  updateAccount: async (_id: string, updates: Record<string, any>) => ({ ...decryptedAccount(), ...updates }),
+  // Mirrors the real AccountManager: echoes the plaintext password back.
+  addAccount: async (acct: Record<string, any>) => ({ ...acct, id: 'new' }),
+};
+
+let httpServer: Server;
+let port: number;
+
+function request(opts: { method?: string; path: string; headers?: Record<string, string>; body?: any }) {
+  const data = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+  const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+  if (data !== undefined) {
+    headers['content-type'] = 'application/json';
+    headers['content-length'] = String(Buffer.byteLength(data));
+  }
+  return new Promise<{ status: number; text: string }>((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, method: opts.method ?? 'GET', path: opts.path, headers },
+      (res) => {
+        let chunks = '';
+        res.on('data', (c) => (chunks += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, text: chunks }));
+      },
+    );
+    req.on('error', reject);
+    if (data !== undefined) req.write(data);
+    req.end();
+  });
+}
+
+beforeAll(async () => {
+  const wizard = new WebUIServer(0, { accountManager: fakeAccountManager as any, imapService: {} as any });
+  await new Promise<void>((resolve) => {
+    httpServer = wizard.getApp().listen(0, () => resolve());
+  });
+  port = (httpServer.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  httpServer?.close();
+});
+
+describe('Web wizard — credential exposure on POST/PUT (Bjoern follow-up)', () => {
+  it('PUT /api/accounts/:id no-op rename does not leak stored passwords', async () => {
+    const res = await request({ method: 'PUT', path: '/api/accounts/a1', body: { name: 'Renamed' } });
+    expect(res.status).toBe(200);
+    // The caller supplied no password yet must not get either back.
+    expect(res.text).not.toContain(IMAP_SECRET);
+    expect(res.text).not.toContain(SMTP_SECRET);
+    const body = JSON.parse(res.text);
+    expect(body.account.password).toBeUndefined();
+    expect(body.account.smtp?.password).toBeUndefined();
+    expect(body.account.name).toBe('Renamed');
+  });
+
+  it('POST /api/accounts does not echo the plaintext password back', async () => {
+    const res = await request({
+      method: 'POST',
+      path: '/api/accounts',
+      body: { name: 'New', host: 'imap.example.com', port: 993, imapUsername: 'u@example.com', password: 'brand-new-pw' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.text).not.toContain('brand-new-pw');
+    const body = JSON.parse(res.text);
+    expect(body.account.password).toBeUndefined();
+  });
+});
+
+describe('Web wizard — loopback / cross-origin guard', () => {
+  it('rejects a cross-origin request (non-loopback Origin)', async () => {
+    const res = await request({ path: '/api/accounts', headers: { Origin: 'http://evil.com' } });
+    expect(res.status).toBe(403);
+    expect(res.text).not.toContain(IMAP_SECRET);
+  });
+
+  it('rejects a non-loopback Host header (DNS rebinding)', async () => {
+    const res = await request({ path: '/api/accounts', headers: { Host: 'evil.com' } });
+    expect(res.status).toBe(403);
+    expect(res.text).not.toContain(IMAP_SECRET);
+  });
+
+  it('allows a same-origin loopback request', async () => {
+    const res = await request({ path: '/api/accounts', headers: { Origin: `http://localhost:${port}` } });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Follow-up to #120. An external researcher (Björn Döbel) found that the first Fix-1 pass only scrubbed the **GET** account routes.

## Gap
- `PUT /api/accounts/:id` returned the **decrypted** account from `updateAccount()` (`res.json({ success: true, account })`). A no-op rename — no password in the request — still returned the stored **plaintext IMAP + SMTP passwords**. With `cors()` open and no auth, any page the user had open could read them.
- `POST /api/accounts` echoed the submitted plaintext password back (less severe, but inconsistent).

## Fix
- `stripAccountSecrets` now applied on **every** account-returning route (POST + PUT, matching the GETs).
- New **loopback-only guard** middleware: rejects non-loopback `Host` (DNS-rebinding) and cross-origin (non-loopback `Origin`) requests.
- Regression tests (`tests/web-server-hardening.test.ts`) reproduce the PoC PUT leak and the guard — 4 fail on the released code, pass here. Full suite: 255 green.

Credit: **Björn Döbel** for the report and PoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)