### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "imap-mcp-server",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imap-mcp-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A powerful Model Context Protocol (MCP) server for IMAP email integration with Claude",
   "mcpName": "io.github.nikolausm/imap-mcp-server",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/nikolausm/imap-mcp-server",
     "source": "github"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "imap-mcp-server",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Patch release shipping the follow-up security fix from #122 (POST/PUT account-route credential exposure + loopback-only guard, reported by Björn Döbel).

- Version bump only: `package.json`, `server.json` (×2), `package-lock.json` — no dependency-tree changes.
- Build + full suite green (255 tests).

After merge, tag `v1.5.2` triggers the release workflow (npm + MCP Registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)