### PR TITLE
fix: report Sent-folder save failures and support per-account sentFolder override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ npm run setup        # launch the web setup wizard
 ```
 
 Always run `npm run build` **and** `npm test` before committing changes that
-touch `src/`. Keep the suite green (currently 169 tests).
+touch `src/`. Keep the suite green (currently 271 tests).
 
 > Note: `npm run lint` (`tsc --noEmit`) is memory-hungry on this project — the
 > MCP SDK's `registerTool` generics are deep enough to surface a pre-existing

--- a/README.md
+++ b/README.md
@@ -273,6 +273,20 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - user: Username
   - password: Password
   - tls: Use TLS/SSL (default: true)
+  - sentFolder: Explicit Sent-folder name for sent-mail copies, e.g. "Gesendet"
+      (optional — only needed when the server has no \Sent SPECIAL-USE folder
+      and auto-detection fails)
+  ```
+
+- **imap_update_account**: Update an existing account (fix SMTP settings, rename, etc.)
+  ```
+  Parameters:
+  - accountId: ID of the account to update
+  - name, host, port, user, password, tls, email: IMAP fields (all optional)
+  - smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword: SMTP fields (optional)
+  - saveToSent: Save sent emails to the Sent folder (optional)
+  - sentFolder: Explicit Sent-folder override (optional). Pass an empty string
+      to clear the override and re-enable auto-detection
   ```
 
 - **imap_list_accounts**: List all configured accounts
@@ -479,6 +493,14 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
     - contentDisposition: "attachment" (default) or "inline" — use "inline" for images shown in the HTML body via cid:
     - cid: Content-ID for inline attachments; must match the `cid:` value used in an `<img src="cid:...">` tag in `html`
   ```
+  After sending, a copy is saved to the account's Sent folder (unless
+  `saveToSent` is disabled on the account). The folder is resolved via the
+  account's `sentFolder` override → the server's `\Sent` SPECIAL-USE flag →
+  a list of known localized names ("Sent", "Gesendet", "Éléments envoyés", …).
+  The response reports the outcome: `savedToSent` (boolean), `sentFolder`
+  (the folder used), and — when the save fails — `sentSaveError` explaining
+  why, instead of failing silently. The same applies to `imap_reply_to_email`
+  and `imap_forward_email`.
 
 - **imap_save_draft**: Save an email as a draft (no send). Takes the same fields as `imap_send_email`, plus `inReplyTo`, `references`, and an optional `folder` override for the Drafts folder.
 
@@ -512,6 +534,10 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   Parameters:
   - accountId: Account ID
   ```
+  Each folder includes its `attributes` (raw IMAP LIST flags) and, when the
+  server advertises it, `specialUse` — the RFC 6154 role (`\Sent`, `\Drafts`,
+  `\Trash`, `\Junk`, `\Archive`) that identifies a folder independent of its
+  localized display name (e.g. "Gesendet" carries `specialUse: "\Sent"`).
 
 - **imap_folder_status**: Get folder information
   ```

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -1,6 +1,6 @@
 import { ImapFlow } from 'imapflow';
 import { simpleParser } from 'mailparser';
-import { ImapAccount, EmailMessage, EmailContent, EmailBodyFormat, EmailLocation, Folder, SearchCriteria, SearchOptions, DEFAULT_BODY_MAX_LENGTH, DEFAULT_BODY_FORMAT, isSystemFlag } from '../types/index.js';
+import { ImapAccount, EmailMessage, EmailContent, EmailBodyFormat, EmailLocation, Folder, SearchCriteria, SearchOptions, SentSaveResult, DEFAULT_BODY_MAX_LENGTH, DEFAULT_BODY_FORMAT, isSystemFlag } from '../types/index.js';
 import type { AccountManager } from './account-manager.js';
 import { htmlToMarkdown, normalizeWhitespace } from './html-to-markdown.js';
 
@@ -1412,14 +1412,22 @@ export class ImapService {
     return { messageIds, uids: sortedUids, messages };
   }
 
-  async appendToSentFolder(accountId: string, rawMessage: Buffer | string): Promise<boolean> {
+  /**
+   * Append a sent message to the account's Sent folder.
+   *
+   * Resolution order: explicit `sentFolderOverride` (the account's configured
+   * `sentFolder`) → SPECIAL-USE `\Sent` flag → localized-name fallback list.
+   * Returns a structured result so callers can report *why* a save failed
+   * instead of a bare `false` (issue #125).
+   */
+  async appendToSentFolder(accountId: string, rawMessage: Buffer | string, sentFolderOverride?: string): Promise<SentSaveResult> {
     const sentFolderNames = [
       // English / standard
       'Sent Messages', 'Sent', 'INBOX.Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail',
       // French (Outlook / Exchange / Sherweb)
       'Éléments envoyés', 'Eléments envoyés', 'Messages envoyés',
       // German
-      'Gesendet', 'Gesendete Elemente', 'Gesendete Objekte',
+      'Gesendet', 'Gesendete Elemente', 'Gesendete Objekte', '[Gmail]/Gesendet',
       // Spanish
       'Enviados', 'Elementos enviados',
       // Portuguese
@@ -1429,12 +1437,30 @@ export class ImapService {
       // Dutch
       'Verzonden', 'Verzonden items',
     ];
-    const folder = await this.findSpecialUseFolder(accountId, '\\Sent', sentFolderNames);
+
+    let folder = sentFolderOverride;
     if (!folder) {
-      console.warn(`[IMAP] No sent folder found for account ${accountId}. Tried SPECIAL-USE flag \\Sent + names: ${sentFolderNames.join(', ')}`);
-      return false;
+      folder = await this.findSpecialUseFolder(accountId, '\\Sent', sentFolderNames);
     }
-    return this.appendMessage(accountId, folder, rawMessage, ['\\Seen']);
+    if (!folder) {
+      const error = 'No Sent folder found: the server advertises no \\Sent SPECIAL-USE folder and no folder matched the known localized names. '
+        + 'Use imap_list_folders to find the right folder and set it as the account\'s sentFolder (imap_update_account).';
+      console.warn(`[IMAP] ${error} (account ${accountId}; names tried: ${sentFolderNames.join(', ')})`);
+      return { saved: false, error };
+    }
+
+    try {
+      const client = await this.ensureConnected(accountId);
+      await client.append(folder, rawMessage, ['\\Seen']);
+      return { saved: true, folder };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.error(`[IMAP] Failed to append sent copy to "${folder}": ${reason}`);
+      const hint = sentFolderOverride
+        ? ' The account\'s configured sentFolder may not exist on the server — check it with imap_list_folders.'
+        : '';
+      return { saved: false, folder, error: `Failed to append to "${folder}": ${reason}.${hint}` };
+    }
   }
 
   async findFolderByNames(accountId: string, candidates: string[]): Promise<string | undefined> {

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -24,8 +24,9 @@ export function accountTools(
       smtpHost: z.string().optional().describe('SMTP server hostname. Defaults to IMAP host with imap.→smtp. rewrite'),
       smtpPort: z.coerce.number().optional().describe('SMTP server port (465 for SMTPS, 587 for STARTTLS). Defaults to 587'),
       smtpSecure: z.boolean().optional().describe('Use implicit TLS (SMTPS). Ignored for port 587/25 which always use STARTTLS, and for port 465 which always uses implicit TLS'),
+      sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Only needed when auto-detection fails — the server must lack a \\Sent SPECIAL-USE folder. Check names with imap_list_folders'),
     }
-  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure }) => {
+  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, sentFolder }) => {
     const smtp = (smtpHost || smtpPort !== undefined || smtpSecure !== undefined)
       ? {
           host: smtpHost || host,
@@ -43,6 +44,7 @@ export function accountTools(
       tls,
       ...(email ? { email } : {}),
       ...(smtp ? { smtp } : {}),
+      ...(sentFolder ? { sentFolder } : {}),
     });
 
     return {
@@ -75,8 +77,9 @@ export function accountTools(
       smtpUser: z.string().optional().describe('SMTP username (if different from IMAP user)'),
       smtpPassword: z.string().optional().describe('SMTP password (if different from IMAP password)'),
       saveToSent: z.boolean().optional().describe('Save sent emails to the Sent folder'),
+      sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Overrides auto-detection; pass an empty string to clear the override and re-enable auto-detection. Check names with imap_list_folders'),
     }
-  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent }) => {
+  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent, sentFolder }) => {
     const existing = accountManager.getAccount(accountId);
     if (!existing) {
       throw new Error(`Account ${accountId} not found`);
@@ -91,6 +94,8 @@ export function accountTools(
     if (tls !== undefined) updates.tls = tls;
     if (email !== undefined) updates.email = email;
     if (saveToSent !== undefined) updates.saveToSent = saveToSent;
+    // Empty string clears the override (falls back to auto-detection).
+    if (sentFolder !== undefined) updates.sentFolder = sentFolder === '' ? undefined : sentFolder;
 
     const smtpTouched = [smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword].some(v => v !== undefined);
     if (smtpTouched) {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -3,7 +3,7 @@ import { ImapService } from '../services/imap-service.js';
 import { AccountManager } from '../services/account-manager.js';
 import { SmtpService } from '../services/smtp-service.js';
 import { selectSearchFolders } from '../utils/search-folders.js';
-import type { EmailMessage } from '../types/index.js';
+import type { EmailMessage, ImapAccount, SentSaveResult } from '../types/index.js';
 import { z } from 'zod';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -51,6 +51,41 @@ const attachmentSchema = z.object({
     'Content-ID for inline attachments. Required when contentDisposition is "inline" and the HTML references the image as <img src="cid:THIS_VALUE">. Must match exactly (without the "cid:" prefix or angle brackets).'
   ),
 });
+
+// Shared by send/reply/forward: copy the outbound message to the Sent folder
+// (honoring the account's saveToSent switch and sentFolder override) and shape
+// the response fields. Failures surface as sentSaveError instead of a silent
+// savedToSent:false (issue #125).
+type SentSaveOutcome = SentSaveResult & { attempted: boolean };
+
+async function saveSentCopy(
+  imapService: ImapService,
+  accountId: string,
+  account: ImapAccount,
+  rawMessage: Buffer | string | undefined,
+): Promise<SentSaveOutcome> {
+  if (!rawMessage || account.saveToSent === false) {
+    return { attempted: false, saved: false };
+  }
+  try {
+    const result = await imapService.appendToSentFolder(accountId, rawMessage, account.sentFolder);
+    return { attempted: true, ...result };
+  } catch (err) {
+    return { attempted: true, saved: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const sentSaveFields = (outcome: SentSaveOutcome) => ({
+  savedToSent: outcome.saved,
+  ...(outcome.folder ? { sentFolder: outcome.folder } : {}),
+  ...(outcome.attempted && !outcome.saved ? { sentSaveError: outcome.error ?? 'Unknown error' } : {}),
+});
+
+const sentSaveSuffix = (outcome: SentSaveOutcome) => {
+  if (outcome.saved) return ` (saved to "${outcome.folder}")`;
+  if (outcome.attempted) return ' (warning: copy NOT saved to Sent folder — see sentSaveError)';
+  return '';
+};
 
 const DOWNLOAD_DIR = process.env.IMAP_DOWNLOAD_DIR || join(homedir(), 'Downloads', 'imap-attachments');
 const MAX_UPLOAD_SIZE = parseInt(process.env.IMAP_MAX_UPLOAD_SIZE ?? '', 10) || 25 * 1024 * 1024;
@@ -857,13 +892,8 @@ export function emailTools(
 
     const { messageId, rawMessage } = await smtpService.sendEmail(accountId, account, emailComposer);
 
-    // Save copy to Sent folder
-    let savedToSent = false;
-    if (rawMessage && account.saveToSent !== false) {
-      try {
-        savedToSent = await imapService.appendToSentFolder(accountId, rawMessage);
-      } catch { /* non-critical */ }
-    }
+    // Save copy to Sent folder (non-critical: the mail is already sent)
+    const sentSave = await saveSentCopy(imapService, accountId, account, rawMessage);
 
     return {
       content: [{
@@ -871,8 +901,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           messageId,
-          savedToSent,
-          message: savedToSent ? 'Email sent successfully (saved to Sent folder)' : 'Email sent successfully',
+          ...sentSaveFields(sentSave),
+          message: `Email sent successfully${sentSaveSuffix(sentSave)}`,
         }, null, 2)
       }]
     };
@@ -1002,13 +1032,8 @@ export function emailTools(
 
     const { messageId, rawMessage } = await smtpService.sendEmail(accountId, account, emailComposer);
 
-    // Save copy to Sent folder
-    let savedToSent = false;
-    if (rawMessage && account.saveToSent !== false) {
-      try {
-        savedToSent = await imapService.appendToSentFolder(accountId, rawMessage);
-      } catch { /* non-critical */ }
-    }
+    // Save copy to Sent folder (non-critical: the mail is already sent)
+    const sentSave = await saveSentCopy(imapService, accountId, account, rawMessage);
 
     return {
       content: [{
@@ -1016,8 +1041,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           messageId,
-          savedToSent,
-          message: savedToSent ? 'Reply sent successfully (saved to Sent folder)' : 'Reply sent successfully',
+          ...sentSaveFields(sentSave),
+          message: `Reply sent successfully${sentSaveSuffix(sentSave)}`,
         }, null, 2)
       }]
     };
@@ -1059,13 +1084,8 @@ export function emailTools(
 
     const { messageId, rawMessage } = await smtpService.sendEmail(accountId, account, emailComposer);
 
-    // Save copy to Sent folder
-    let savedToSent = false;
-    if (rawMessage && account.saveToSent !== false) {
-      try {
-        savedToSent = await imapService.appendToSentFolder(accountId, rawMessage);
-      } catch { /* non-critical */ }
-    }
+    // Save copy to Sent folder (non-critical: the mail is already sent)
+    const sentSave = await saveSentCopy(imapService, accountId, account, rawMessage);
 
     return {
       content: [{
@@ -1073,8 +1093,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           messageId,
-          savedToSent,
-          message: savedToSent ? 'Email forwarded successfully (saved to Sent folder)' : 'Email forwarded successfully',
+          ...sentSaveFields(sentSave),
+          message: `Email forwarded successfully${sentSaveSuffix(sentSave)}`,
         }, null, 2)
       }]
     };

--- a/src/tools/folder-tools.ts
+++ b/src/tools/folder-tools.ts
@@ -18,7 +18,7 @@ export function folderTools(
 ): void {
   // List folders tool
   server.registerTool('imap_list_folders', {
-    description: 'List all folders/mailboxes for an account (names, hierarchy delimiter, attributes). Use this first to discover exact folder names before searching, moving, or creating subfolders — folder naming varies by provider (e.g. "Archive" vs "[Gmail]/All Mail" vs "INBOX.Archive").',
+    description: 'List all folders/mailboxes for an account (names, hierarchy delimiter, attributes, RFC 6154 special-use role). Use this first to discover exact folder names before searching, moving, or creating subfolders — folder naming varies by provider (e.g. "Archive" vs "[Gmail]/All Mail" vs "INBOX.Archive"). The specialUse field ("\\\\Sent", "\\\\Drafts", "\\\\Trash", "\\\\Junk", "\\\\Archive") identifies a folder\'s role independent of its localized name (e.g. "Gesendet" is the Sent folder when specialUse is "\\\\Sent").',
     inputSchema: {
       ...accountSelector,
     }
@@ -34,6 +34,9 @@ export function folderTools(
             name: folder.name,
             delimiter: folder.delimiter,
             attributes: folder.attributes,
+            // RFC 6154 special-use role (language-independent): lets callers
+            // find e.g. the Sent folder even when it is named "Gesendet".
+            specialUse: folder.specialUse,
             hasChildren: !!folder.children && folder.children.length > 0,
           })),
         }, null, 2)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,10 @@ export interface ImapAccount {
   keepalive?: boolean;
   smtp?: SmtpConfig;
   saveToSent?: boolean;
+  /** Explicit Sent-folder name (e.g. "Gesendet", "[Gmail]/Gesendete Objekte").
+   * When set, sent-mail copies are appended here, skipping SPECIAL-USE /
+   * localized-name auto-detection. Leave unset to auto-detect. */
+  sentFolder?: string;
 }
 
 export interface SmtpConfig {
@@ -57,6 +61,16 @@ export interface Attachment {
   contentId?: string;
   textContent?: string;
   textContentTruncated?: boolean;
+}
+
+/** Outcome of copying a sent message into the Sent folder. `error` explains
+ * a failure instead of the save silently reporting `false` (issue #125). */
+export interface SentSaveResult {
+  saved: boolean;
+  /** Folder the append targeted (resolved or overridden). Absent when no Sent folder could be found. */
+  folder?: string;
+  /** Why the save failed, when `saved` is false. */
+  error?: string;
 }
 
 export interface Folder {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -135,8 +135,8 @@ export class WebUIServer {
     // Add new account
     this.app.post('/api/accounts', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp, imapUsername } = req.body;
-        
+        const { name, email, password, host, port, tls, smtp, imapUsername, sentFolder } = req.body;
+
         // Auto-detect provider if not specified
         let imapHost = host;
         let imapPort = port;
@@ -160,6 +160,7 @@ export class WebUIServer {
           tls: useTls !== false,
           ...(imapUsername ? { email } : {}),
           smtp: smtp || undefined,
+          ...(typeof sentFolder === 'string' && sentFolder ? { sentFolder } : {}),
         });
 
         // addAccount returns the plaintext password back; never echo it.
@@ -225,7 +226,7 @@ export class WebUIServer {
     // Update account
     this.app.put('/api/accounts/:id', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp, saveToSent, imapUsername } = req.body;
+        const { name, email, password, host, port, tls, smtp, saveToSent, imapUsername, sentFolder } = req.body;
 
         const updates: any = {};
         if (name !== undefined) updates.name = name;
@@ -242,7 +243,9 @@ export class WebUIServer {
         if (tls !== undefined) updates.tls = tls;
         if (smtp !== undefined) updates.smtp = smtp;
         if (saveToSent !== undefined) updates.saveToSent = saveToSent;
-        
+        // Empty string clears the override (falls back to auto-detection).
+        if (typeof sentFolder === 'string') updates.sentFolder = sentFolder === '' ? undefined : sentFolder;
+
         // updateAccount returns a DECRYPTED account (plaintext IMAP + SMTP
         // passwords). A no-op update (e.g. a rename with no password supplied)
         // would otherwise hand every stored secret back over the wire — strip.

--- a/tests/account-tools-sent-folder.test.ts
+++ b/tests/account-tools-sent-folder.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { accountTools } from '../src/tools/account-tools.js';
+
+/**
+ * Covers the sentFolder override plumbing on imap_add_account /
+ * imap_update_account (issue #125).
+ */
+let addAccountHandler: Function;
+let updateAccountHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_add_account') addAccountHandler = handler;
+    if (name === 'imap_update_account') updateAccountHandler = handler;
+  }),
+};
+
+const mockAccountManager = {
+  addAccount: vi.fn(async (acc: any) => ({ ...acc, id: 'acc1' })),
+  getAccount: vi.fn(() => ({ id: 'acc1', name: 'Test', host: 'imap.example.com' })),
+  updateAccount: vi.fn(async (id: string, updates: any) => ({ id, name: 'Test', ...updates })),
+};
+
+const mockImapService = {};
+const mockSmtpService = { disconnect: vi.fn() };
+
+describe('account tools sentFolder override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accountTools(
+      mockServer as any,
+      mockAccountManager as any,
+      mockImapService as any,
+      mockSmtpService as any,
+    );
+  });
+
+  it('imap_add_account stores a sentFolder override', async () => {
+    await addAccountHandler({
+      name: 'Test',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: 'pw',
+      tls: true,
+      sentFolder: 'Gesendet',
+    });
+
+    expect(mockAccountManager.addAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ sentFolder: 'Gesendet' }),
+    );
+  });
+
+  it('imap_add_account omits sentFolder when not provided', async () => {
+    await addAccountHandler({
+      name: 'Test',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: 'pw',
+      tls: true,
+    });
+
+    const stored = mockAccountManager.addAccount.mock.calls[0][0];
+    expect('sentFolder' in stored).toBe(false);
+  });
+
+  it('imap_update_account sets a sentFolder override', async () => {
+    await updateAccountHandler({ accountId: 'acc1', sentFolder: '[Gmail]/Gesendet' });
+
+    expect(mockAccountManager.updateAccount).toHaveBeenCalledWith(
+      'acc1',
+      expect.objectContaining({ sentFolder: '[Gmail]/Gesendet' }),
+    );
+  });
+
+  it('imap_update_account clears the override when given an empty string', async () => {
+    await updateAccountHandler({ accountId: 'acc1', sentFolder: '' });
+
+    const updates = mockAccountManager.updateAccount.mock.calls[0][1];
+    expect('sentFolder' in updates).toBe(true);
+    expect(updates.sentFolder).toBeUndefined();
+  });
+
+  it('imap_update_account leaves sentFolder untouched when not provided', async () => {
+    await updateAccountHandler({ accountId: 'acc1', name: 'Renamed' });
+
+    const updates = mockAccountManager.updateAccount.mock.calls[0][1];
+    expect('sentFolder' in updates).toBe(false);
+  });
+});

--- a/tests/email-tools-sent-save.test.ts
+++ b/tests/email-tools-sent-save.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { emailTools } from '../src/tools/email-tools.js';
+
+/**
+ * Covers the Sent-copy reporting of imap_send_email — issue #125: when the
+ * copy cannot be saved, the tool response must say so (sentSaveError) instead
+ * of a bare savedToSent:false, and the account's sentFolder override must be
+ * passed through to the service.
+ */
+let sendEmailHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_send_email') {
+      sendEmailHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  appendToSentFolder: vi.fn(),
+};
+
+const account: any = {
+  id: 'acc1',
+  name: 'Test',
+  email: 'user@example.com',
+  user: 'user@example.com',
+};
+
+const mockAccountManager = {
+  resolveAccountId: (id: string) => id,
+  getAccount: vi.fn(async () => account),
+};
+
+const mockSmtpService = {
+  sendEmail: vi.fn(async () => ({ messageId: '<msg-1@example.com>', rawMessage: 'RAW' })),
+};
+
+const sendArgs = { accountId: 'acc1', to: 'rcpt@example.com', subject: 'Hi', text: 'Hello' };
+
+describe('imap_send_email Sent-copy reporting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete account.saveToSent;
+    delete account.sentFolder;
+    emailTools(
+      mockServer as any,
+      mockImapService as any,
+      mockAccountManager as any,
+      mockSmtpService as any,
+    );
+  });
+
+  it('reports the folder the copy was saved to', async () => {
+    mockImapService.appendToSentFolder.mockResolvedValueOnce({ saved: true, folder: 'Gesendet' });
+
+    const result = await sendEmailHandler(sendArgs);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.savedToSent).toBe(true);
+    expect(parsed.sentFolder).toBe('Gesendet');
+    expect(parsed.sentSaveError).toBeUndefined();
+    expect(parsed.message).toContain('saved to "Gesendet"');
+  });
+
+  it('passes the account sentFolder override to the service', async () => {
+    account.sentFolder = 'Custom/Sent';
+    mockImapService.appendToSentFolder.mockResolvedValueOnce({ saved: true, folder: 'Custom/Sent' });
+
+    await sendEmailHandler(sendArgs);
+
+    expect(mockImapService.appendToSentFolder).toHaveBeenCalledWith('acc1', 'RAW', 'Custom/Sent');
+  });
+
+  it('surfaces the failure reason as sentSaveError instead of failing silently', async () => {
+    mockImapService.appendToSentFolder.mockResolvedValueOnce({
+      saved: false,
+      error: 'No Sent folder found: the server advertises no \\Sent SPECIAL-USE folder…',
+    });
+
+    const result = await sendEmailHandler(sendArgs);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true); // the send itself succeeded
+    expect(parsed.savedToSent).toBe(false);
+    expect(parsed.sentSaveError).toContain('No Sent folder found');
+    expect(parsed.message).toContain('NOT saved to Sent folder');
+  });
+
+  it('reports an unexpected service exception as sentSaveError', async () => {
+    mockImapService.appendToSentFolder.mockRejectedValueOnce(new Error('connection lost'));
+
+    const result = await sendEmailHandler(sendArgs);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.savedToSent).toBe(false);
+    expect(parsed.sentSaveError).toBe('connection lost');
+  });
+
+  it('skips the save (no error, no attempt) when saveToSent is disabled', async () => {
+    account.saveToSent = false;
+
+    const result = await sendEmailHandler(sendArgs);
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(mockImapService.appendToSentFolder).not.toHaveBeenCalled();
+    expect(parsed.savedToSent).toBe(false);
+    expect(parsed.sentSaveError).toBeUndefined();
+    expect(parsed.message).toBe('Email sent successfully');
+  });
+});

--- a/tests/folder-tools-list.test.ts
+++ b/tests/folder-tools-list.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { folderTools } from '../src/tools/folder-tools.js';
+
+/**
+ * Covers imap_list_folders — issue #125: the tool must expose the RFC 6154
+ * special-use role so callers can identify localized folders ("Gesendet" →
+ * \Sent) without guessing by name.
+ */
+let listFoldersHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_list_folders') {
+      listFoldersHandler = handler;
+    }
+  }),
+};
+
+const mockImapService = {
+  listFolders: vi.fn(),
+};
+
+describe('imap_list_folders Tool Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    folderTools(mockServer as any, mockImapService as any, { resolveAccountId: (id: string) => id } as any);
+  });
+
+  it('exposes attributes and the RFC 6154 specialUse role per folder', async () => {
+    mockImapService.listFolders.mockResolvedValueOnce([
+      { name: 'INBOX', delimiter: '/', attributes: ['\\HasNoChildren'] },
+      { name: 'Gesendet', delimiter: '/', attributes: ['\\HasNoChildren', '\\Sent'], specialUse: '\\Sent' },
+      { name: 'Entwürfe', delimiter: '/', attributes: ['\\HasNoChildren', '\\Drafts'], specialUse: '\\Drafts' },
+    ]);
+
+    const result = await listFoldersHandler({ accountId: 'acc1' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.folders).toHaveLength(3);
+    expect(parsed.folders[1]).toMatchObject({
+      name: 'Gesendet',
+      attributes: ['\\HasNoChildren', '\\Sent'],
+      specialUse: '\\Sent',
+    });
+    // Folders without a special-use role simply omit the field (JSON drops undefined).
+    expect(parsed.folders[0].specialUse).toBeUndefined();
+    expect(parsed.folders[0].attributes).toEqual(['\\HasNoChildren']);
+  });
+});

--- a/tests/imap-service-sent-save.test.ts
+++ b/tests/imap-service-sent-save.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ImapService } from '../src/services/imap-service.js';
+
+/**
+ * Covers appendToSentFolder() — issue #125: sent-folder auto-save must not
+ * fail silently. The method now returns a structured { saved, folder, error }
+ * result and honors a per-account sentFolder override.
+ */
+describe('ImapService.appendToSentFolder', () => {
+  let service: ImapService;
+  let append: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    service = new ImapService();
+    vi.restoreAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    append = vi.fn().mockResolvedValue(undefined);
+    vi.spyOn(service as any, 'ensureConnected').mockResolvedValue({ append });
+  });
+
+  it('saves to the auto-detected Sent folder and reports which one', async () => {
+    vi.spyOn(service, 'findSpecialUseFolder').mockResolvedValue('Gesendet');
+
+    const result = await service.appendToSentFolder('acc1', 'raw message');
+
+    expect(result).toEqual({ saved: true, folder: 'Gesendet' });
+    expect(append).toHaveBeenCalledWith('Gesendet', 'raw message', ['\\Seen']);
+  });
+
+  it('uses the sentFolder override and skips auto-detection', async () => {
+    const detect = vi.spyOn(service, 'findSpecialUseFolder');
+
+    const result = await service.appendToSentFolder('acc1', 'raw message', '[Gmail]/Gesendet');
+
+    expect(result).toEqual({ saved: true, folder: '[Gmail]/Gesendet' });
+    expect(detect).not.toHaveBeenCalled();
+    expect(append).toHaveBeenCalledWith('[Gmail]/Gesendet', 'raw message', ['\\Seen']);
+  });
+
+  it('returns an actionable error when no Sent folder can be found', async () => {
+    vi.spyOn(service, 'findSpecialUseFolder').mockResolvedValue(undefined);
+
+    const result = await service.appendToSentFolder('acc1', 'raw message');
+
+    expect(result.saved).toBe(false);
+    expect(result.folder).toBeUndefined();
+    expect(result.error).toContain('No Sent folder found');
+    expect(result.error).toContain('sentFolder');
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it('returns the append failure reason instead of a silent false', async () => {
+    vi.spyOn(service, 'findSpecialUseFolder').mockResolvedValue('Sent');
+    append.mockRejectedValueOnce(new Error('Mailbox does not exist'));
+
+    const result = await service.appendToSentFolder('acc1', 'raw message');
+
+    expect(result.saved).toBe(false);
+    expect(result.folder).toBe('Sent');
+    expect(result.error).toContain('Failed to append to "Sent"');
+    expect(result.error).toContain('Mailbox does not exist');
+  });
+
+  it('hints at a bad override when appending to the configured sentFolder fails', async () => {
+    append.mockRejectedValueOnce(new Error('NO [NONEXISTENT] Unknown Mailbox'));
+
+    const result = await service.appendToSentFolder('acc1', 'raw message', 'Typo/Sent');
+
+    expect(result.saved).toBe(false);
+    expect(result.folder).toBe('Typo/Sent');
+    expect(result.error).toContain('configured sentFolder');
+  });
+});


### PR DESCRIPTION
Fixes #125

## Problem

`imap_send_email` (and reply/forward) silently failed to save a copy to the
Sent folder on accounts whose folder isn't named "Sent" — e.g. German
"Gesendet" or Gmail's "[Gmail]/Gesendet". The tools returned
`savedToSent: false` with no explanation, and `imap_list_folders` gave
callers no way to identify the right folder, since the RFC 6154
SPECIAL-USE role wasn't exposed.

## Changes

- **`imap_list_folders` exposes `specialUse`** — each folder now reports its
  RFC 6154 role (`\Sent`, `\Drafts`, `\Trash`, `\Junk`, `\Archive`) alongside
  the raw LIST `attributes`, so localized folders are identifiable without
  name-guessing.
- **Per-account `sentFolder` override** — new optional field on
  `imap_add_account`, `imap_update_account`, and the web setup wizard routes.
  When set, sent-mail copies are appended there directly, skipping
  auto-detection. Passing an empty string on update clears the override.
- **No more silent failures** — `appendToSentFolder` returns a structured
  `{ saved, folder, error }` result. `imap_send_email`, `imap_reply_to_email`,
  and `imap_forward_email` now report the resolved `sentFolder` on success and
  a `sentSaveError` with an actionable message on failure (e.g. pointing at
  `imap_list_folders` + the `sentFolder` override when the server advertises
  no `\Sent` folder).
- Added `[Gmail]/Gesendet` to the localized fallback-name list.

All changes are additive and backward-compatible: no tool was renamed and
`savedToSent` keeps its existing shape; `sentFolder` / `sentSaveError` are
new optional response fields.

## Testing

- 16 new tests across 4 files: structured save results (detection, override,
  not-found, append-failure paths), tool response fields, override
  set/clear/untouched plumbing, and `specialUse` exposure.
- `npm run build` clean; full suite green: **271 passed** (was 255).