### PR TITLE
feat: optional per-account defaultBcc for outbound mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - sentFolder: Explicit Sent-folder name for sent-mail copies, e.g. "Gesendet"
       (optional — only needed when the server has no \Sent SPECIAL-USE folder
       and auto-detection fails)
+  - defaultBcc: Optional BCC address(es) applied automatically to every
+      outbound send, reply, forward, and draft for this account. Merged with
+      any per-call `bcc` (duplicates removed case-insensitively)
   ```
 
 - **imap_update_account**: Update an existing account (fix SMTP settings, rename, etc.)
@@ -287,6 +290,8 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - saveToSent: Save sent emails to the Sent folder (optional)
   - sentFolder: Explicit Sent-folder override (optional). Pass an empty string
       to clear the override and re-enable auto-detection
+  - defaultBcc: Optional default BCC address(es) (optional). Pass an empty
+      string to clear
   ```
 
 - **imap_list_accounts**: List all configured accounts
@@ -502,6 +507,10 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   why, instead of failing silently. The same applies to `imap_reply_to_email`
   and `imap_forward_email`.
 
+  When the account has `defaultBcc` configured, those address(es) are always
+  BCC'd on send, reply, forward, and draft (merged with any per-call `bcc`;
+  duplicates removed case-insensitively).
+
 - **imap_save_draft**: Save an email as a draft (no send). Takes the same fields as `imap_send_email`, plus `inReplyTo`, `references`, and an optional `folder` override for the Drafts folder.
 
 - **imap_reply_to_email**: Reply to an existing email
@@ -513,6 +522,7 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - text: Plain text reply content (optional)
   - html: HTML reply content (optional)
   - replyAll: Reply to all recipients (default: false)
+  - bcc: BCC recipients (optional; merged with account defaultBcc)
   - attachments: Array of attachments (optional, same shape as imap_send_email, including contentDisposition/cid for inline images)
   ```
 
@@ -524,6 +534,7 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - uid: UID of the email to forward
   - to: Forward to email address(es)
   - text: Additional text to include (optional)
+  - bcc: BCC recipients (optional; merged with account defaultBcc)
   - includeAttachments: Include original attachments (default: true)
   ```
 

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -25,8 +25,9 @@ export function accountTools(
       smtpPort: z.coerce.number().optional().describe('SMTP server port (465 for SMTPS, 587 for STARTTLS). Defaults to 587'),
       smtpSecure: z.boolean().optional().describe('Use implicit TLS (SMTPS). Ignored for port 587/25 which always use STARTTLS, and for port 465 which always uses implicit TLS'),
       sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Only needed when auto-detection fails — the server must lack a \\Sent SPECIAL-USE folder. Check names with imap_list_folders'),
+      defaultBcc: z.union([z.string(), z.array(z.string())]).optional().describe('Optional BCC address(es) applied automatically to every outbound send, reply, forward, and draft for this account. Merged with any per-call bcc'),
     }
-  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, sentFolder }) => {
+  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, sentFolder, defaultBcc }) => {
     const smtp = (smtpHost || smtpPort !== undefined || smtpSecure !== undefined)
       ? {
           host: smtpHost || host,
@@ -45,6 +46,9 @@ export function accountTools(
       ...(email ? { email } : {}),
       ...(smtp ? { smtp } : {}),
       ...(sentFolder ? { sentFolder } : {}),
+      ...(defaultBcc !== undefined && defaultBcc !== '' && !(Array.isArray(defaultBcc) && defaultBcc.length === 0)
+        ? { defaultBcc }
+        : {}),
     });
 
     return {
@@ -78,8 +82,9 @@ export function accountTools(
       smtpPassword: z.string().optional().describe('SMTP password (if different from IMAP password)'),
       saveToSent: z.boolean().optional().describe('Save sent emails to the Sent folder'),
       sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Overrides auto-detection; pass an empty string to clear the override and re-enable auto-detection. Check names with imap_list_folders'),
+      defaultBcc: z.union([z.string(), z.array(z.string())]).optional().describe('Optional BCC address(es) applied automatically to every outbound message for this account. Pass an empty string to clear'),
     }
-  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent, sentFolder }) => {
+  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent, sentFolder, defaultBcc }) => {
     const existing = accountManager.getAccount(accountId);
     if (!existing) {
       throw new Error(`Account ${accountId} not found`);
@@ -96,6 +101,14 @@ export function accountTools(
     if (saveToSent !== undefined) updates.saveToSent = saveToSent;
     // Empty string clears the override (falls back to auto-detection).
     if (sentFolder !== undefined) updates.sentFolder = sentFolder === '' ? undefined : sentFolder;
+    // Empty string (or empty array) clears the default BCC.
+    if (defaultBcc !== undefined) {
+      if (defaultBcc === '' || (Array.isArray(defaultBcc) && defaultBcc.length === 0)) {
+        updates.defaultBcc = undefined;
+      } else {
+        updates.defaultBcc = defaultBcc;
+      }
+    }
 
     const smtpTouched = [smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword].some(v => v !== undefined);
     if (smtpTouched) {

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -3,6 +3,7 @@ import { ImapService } from '../services/imap-service.js';
 import { AccountManager } from '../services/account-manager.js';
 import { SmtpService } from '../services/smtp-service.js';
 import { selectSearchFolders } from '../utils/search-folders.js';
+import { mergeBcc } from '../utils/default-bcc.js';
 import type { EmailMessage, ImapAccount, SentSaveResult } from '../types/index.js';
 import { z } from 'zod';
 import { join } from 'path';
@@ -37,6 +38,13 @@ const buildAttachments = (atts?: AttachmentInput[]) =>
     cid: att.cid,
   }));
 
+// Merge the account's defaultBcc with a per-call bcc (same pattern as
+// saveSentCopy honoring saveToSent / sentFolder on the account).
+const resolveBcc = (
+  account: ImapAccount,
+  explicitBcc?: string | string[],
+): string | string[] | undefined => mergeBcc(account.defaultBcc, explicitBcc);
+
 // Shared Zod shape for the attachments arrays on send/save_draft/reply — keeps
 // the three tool schemas (and their .describe() text) in sync.
 const attachmentSchema = z.object({
@@ -51,6 +59,11 @@ const attachmentSchema = z.object({
     'Content-ID for inline attachments. Required when contentDisposition is "inline" and the HTML references the image as <img src="cid:THIS_VALUE">. Must match exactly (without the "cid:" prefix or angle brackets).'
   ),
 });
+
+// Shared bcc field for send/draft/reply/forward — keeps merge wording in sync.
+const bccSchema = z.union([z.string(), z.array(z.string())]).optional().describe(
+  'BCC recipients (merged with the account defaultBcc when set)',
+);
 
 // Shared by send/reply/forward: copy the outbound message to the Sent folder
 // (honoring the account's saveToSent switch and sentFolder override) and shape
@@ -858,7 +871,7 @@ export function emailTools(
 
   // Send email tool
   server.registerTool('imap_send_email', {
-    description: 'Compose and send a NEW email via the account\'s SMTP server (a copy is saved to Sent unless disabled). Use for fresh outbound messages. To respond to an existing message use imap_reply_to_email (keeps threading); to pass a message on use imap_forward_email; to store without sending use imap_save_draft. Supports to/cc/bcc, text and/or HTML, and attachments by base64 content or by file path (see imap_upload_file for large files).',
+    description: 'Compose and send a NEW email via the account\'s SMTP server (a copy is saved to Sent unless disabled; account defaultBcc addresses are always BCC\'d when configured). Use for fresh outbound messages. To respond to an existing message use imap_reply_to_email (keeps threading); to pass a message on use imap_forward_email; to store without sending use imap_save_draft. Supports to/cc/bcc, text and/or HTML, and attachments by base64 content or by file path (see imap_upload_file for large files).',
     inputSchema: {
       ...accountSelector,
       to: z.union([z.string(), z.array(z.string())]).describe('Recipient email address(es)'),
@@ -867,7 +880,7 @@ export function emailTools(
       html: z.string().optional().describe('HTML content'),
       body: z.string().optional().describe("Alias for 'text' (backward-compat with clients that pass 'body')"),
       cc: z.union([z.string(), z.array(z.string())]).optional().describe('CC recipients'),
-      bcc: z.union([z.string(), z.array(z.string())]).optional().describe('BCC recipients'),
+      bcc: bccSchema,
       replyTo: z.string().optional().describe('Reply-to address'),
       attachments: z.array(attachmentSchema).optional().describe('Email attachments'),
     }
@@ -885,7 +898,7 @@ export function emailTools(
       text: text ?? body,
       html,
       cc,
-      bcc,
+      bcc: resolveBcc(account, bcc),
       replyTo,
       attachments: buildAttachments(attachments as AttachmentInput[] | undefined),
     };
@@ -910,7 +923,7 @@ export function emailTools(
 
   // Save draft tool — composes a message and appends it to the Drafts folder with the \Draft flag
   server.registerTool('imap_save_draft', {
-    description: 'Save an email as a draft in the Drafts folder (no send). Takes the same fields as imap_send_email.',
+    description: 'Save an email as a draft in the Drafts folder (no send). Takes the same fields as imap_send_email (including account defaultBcc when configured).',
     inputSchema: {
       ...accountSelector,
       to: z.union([z.string(), z.array(z.string())]).optional().describe('Recipient email address(es)'),
@@ -919,7 +932,7 @@ export function emailTools(
       html: z.string().optional().describe('HTML content'),
       body: z.string().optional().describe("Alias for 'text' (backward-compat)"),
       cc: z.union([z.string(), z.array(z.string())]).optional().describe('CC recipients'),
-      bcc: z.union([z.string(), z.array(z.string())]).optional().describe('BCC recipients'),
+      bcc: bccSchema,
       replyTo: z.string().optional().describe('Reply-to address'),
       inReplyTo: z.string().optional().describe('Message-Id being replied to'),
       references: z.union([z.string(), z.array(z.string())]).optional().describe('References header value(s)'),
@@ -940,7 +953,7 @@ export function emailTools(
       text: text ?? body,
       html,
       cc,
-      bcc,
+      bcc: resolveBcc(account, bcc),
       replyTo,
       inReplyTo,
       references,
@@ -973,7 +986,7 @@ export function emailTools(
 
   // Reply to email tool
   server.registerTool('imap_reply_to_email', {
-    description: 'Reply to an existing email identified by folder + uid. Automatically sets the recipient to the original sender, prefixes the subject with "Re:", and preserves threading (In-Reply-To/References). Set replyAll to also include the original recipients. Use this instead of imap_send_email whenever the user is responding to a message already in a mailbox.',
+    description: 'Reply to an existing email identified by folder + uid. Automatically sets the recipient to the original sender, prefixes the subject with "Re:", and preserves threading (In-Reply-To/References). Set replyAll to also include the original recipients. Use this instead of imap_send_email whenever the user is responding to a message already in a mailbox. Account defaultBcc addresses are always BCC\'d when configured.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder containing the original email'),
@@ -982,9 +995,10 @@ export function emailTools(
       html: z.string().optional().describe('HTML reply content'),
       body: z.string().optional().describe("Alias for 'text' (backward-compat)"),
       replyAll: z.boolean().default(false).describe('Reply to all recipients'),
+      bcc: bccSchema,
       attachments: z.array(attachmentSchema).optional().describe('Email attachments'),
     }
-  }, async ({ accountId: rawAccountId, accountName, folder, uid, text, html, body, replyAll, attachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, text, html, body, replyAll, bcc, attachments }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
@@ -1025,6 +1039,7 @@ export function emailTools(
       subject: originalEmail.subject.startsWith('Re: ') ? originalEmail.subject : `Re: ${originalEmail.subject}`,
       text: text ?? body,
       html,
+      bcc: resolveBcc(account, bcc),
       inReplyTo: originalEmail.messageId,
       references: originalEmail.messageId,
       attachments: buildAttachments(attachments as AttachmentInput[] | undefined),
@@ -1050,7 +1065,7 @@ export function emailTools(
 
   // Forward email tool
   server.registerTool('imap_forward_email', {
-    description: 'Forward an existing email (folder + uid) to new recipients, quoting the original message and headers. Optionally include the original attachments. Use when the user wants to pass an existing message on to someone else; use imap_reply_to_email instead to respond to the sender.',
+    description: 'Forward an existing email (folder + uid) to new recipients, quoting the original message and headers. Optionally include the original attachments. Use when the user wants to pass an existing message on to someone else; use imap_reply_to_email instead to respond to the sender. Account defaultBcc addresses are always BCC\'d when configured.',
     inputSchema: {
       ...accountSelector,
       folder: z.string().default('INBOX').describe('Folder containing the original email'),
@@ -1058,9 +1073,10 @@ export function emailTools(
       to: z.union([z.string(), z.array(z.string())]).describe('Forward to email address(es)'),
       text: z.string().optional().describe('Additional text to include'),
       body: z.string().optional().describe("Alias for 'text' (backward-compat)"),
+      bcc: bccSchema,
       includeAttachments: z.boolean().default(true).describe('Include original attachments'),
     }
-  }, async ({ accountId: rawAccountId, accountName, folder, uid, to, text, body, includeAttachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, folder, uid, to, text, body, bcc, includeAttachments }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
@@ -1079,6 +1095,7 @@ export function emailTools(
       subject: originalEmail.subject.startsWith('Fwd: ') ? originalEmail.subject : `Fwd: ${originalEmail.subject}`,
       text: (text ?? body ?? '') + forwardHeader + (originalEmail.textContent || ''),
       html: originalEmail.htmlContent,
+      bcc: resolveBcc(account, bcc),
       references: originalEmail.messageId,
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,10 @@ export interface ImapAccount {
    * When set, sent-mail copies are appended here, skipping SPECIAL-USE /
    * localized-name auto-detection. Leave unset to auto-detect. */
   sentFolder?: string;
+  /** Optional BCC address(es) applied to every outbound send, reply, forward,
+   * and draft. Merged with any per-call `bcc` (call-site values win for
+   * ordering; duplicates are removed case-insensitively). */
+  defaultBcc?: string | string[];
 }
 
 export interface SmtpConfig {

--- a/src/utils/default-bcc.ts
+++ b/src/utils/default-bcc.ts
@@ -1,0 +1,35 @@
+/**
+ * Merge an account-level default BCC list with an explicit per-call BCC value.
+ * Explicit addresses come first; defaults are appended. Deduplication is
+ * case-insensitive on the bare address (display-name wrappers ignored).
+ * Returns `undefined` when the merge is empty, a single string for one
+ * recipient, or an array for multiple — matching nodemailer's bcc shape.
+ */
+export function mergeBcc(
+  defaultBcc: string | string[] | undefined,
+  explicitBcc: string | string[] | undefined,
+): string | string[] | undefined {
+  const normalize = (value?: string | string[]): string[] => {
+    if (value === undefined || value === null) return [];
+    const list = Array.isArray(value) ? value : [value];
+    return list.map((entry) => entry.trim()).filter(Boolean);
+  };
+
+  const bareAddress = (addr: string): string => {
+    const match = addr.match(/<([^>]+)>/);
+    return (match ? match[1] : addr).trim().toLowerCase();
+  };
+
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const addr of [...normalize(explicitBcc), ...normalize(defaultBcc)]) {
+    const key = bareAddress(addr);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    merged.push(addr);
+  }
+
+  if (merged.length === 0) return undefined;
+  if (merged.length === 1) return merged[0];
+  return merged;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -135,7 +135,7 @@ export class WebUIServer {
     // Add new account
     this.app.post('/api/accounts', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp, imapUsername, sentFolder } = req.body;
+        const { name, email, password, host, port, tls, smtp, imapUsername, sentFolder, defaultBcc } = req.body;
 
         // Auto-detect provider if not specified
         let imapHost = host;
@@ -161,6 +161,9 @@ export class WebUIServer {
           ...(imapUsername ? { email } : {}),
           smtp: smtp || undefined,
           ...(typeof sentFolder === 'string' && sentFolder ? { sentFolder } : {}),
+          ...(defaultBcc !== undefined && defaultBcc !== '' && !(Array.isArray(defaultBcc) && defaultBcc.length === 0)
+            ? { defaultBcc }
+            : {}),
         });
 
         // addAccount returns the plaintext password back; never echo it.
@@ -226,7 +229,7 @@ export class WebUIServer {
     // Update account
     this.app.put('/api/accounts/:id', async (req, res) => {
       try {
-        const { name, email, password, host, port, tls, smtp, saveToSent, imapUsername, sentFolder } = req.body;
+        const { name, email, password, host, port, tls, smtp, saveToSent, imapUsername, sentFolder, defaultBcc } = req.body;
 
         const updates: any = {};
         if (name !== undefined) updates.name = name;
@@ -245,6 +248,13 @@ export class WebUIServer {
         if (saveToSent !== undefined) updates.saveToSent = saveToSent;
         // Empty string clears the override (falls back to auto-detection).
         if (typeof sentFolder === 'string') updates.sentFolder = sentFolder === '' ? undefined : sentFolder;
+        if (defaultBcc !== undefined) {
+          if (defaultBcc === '' || (Array.isArray(defaultBcc) && defaultBcc.length === 0)) {
+            updates.defaultBcc = undefined;
+          } else {
+            updates.defaultBcc = defaultBcc;
+          }
+        }
 
         // updateAccount returns a DECRYPTED account (plaintext IMAP + SMTP
         // passwords). A no-op update (e.g. a rename with no password supplied)

--- a/tests/default-bcc.test.ts
+++ b/tests/default-bcc.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mergeBcc } from '../src/utils/default-bcc.js';
+import { accountTools } from '../src/tools/account-tools.js';
+import { emailTools } from '../src/tools/email-tools.js';
+
+/**
+ * Covers the defaultBcc account override — same plumbing shape as
+ * account-tools-sent-folder.test.ts / email-tools-sent-save.test.ts.
+ */
+describe('mergeBcc', () => {
+  it('returns undefined when neither side has addresses', () => {
+    expect(mergeBcc(undefined, undefined)).toBeUndefined();
+    expect(mergeBcc('', '')).toBeUndefined();
+    expect(mergeBcc([], [])).toBeUndefined();
+  });
+
+  it('returns the explicit bcc alone when no default is set', () => {
+    expect(mergeBcc(undefined, 'me@example.com')).toBe('me@example.com');
+    expect(mergeBcc(undefined, ['a@x.com', 'b@x.com'])).toEqual(['a@x.com', 'b@x.com']);
+  });
+
+  it('returns the default alone when no explicit bcc is set', () => {
+    expect(mergeBcc('me@example.com', undefined)).toBe('me@example.com');
+  });
+
+  it('merges explicit first, then defaults, and dedupes case-insensitively', () => {
+    expect(mergeBcc('Me@Example.com', 'other@example.com')).toEqual([
+      'other@example.com',
+      'Me@Example.com',
+    ]);
+    expect(mergeBcc('me@example.com', 'ME@example.com')).toBe('ME@example.com');
+  });
+
+  it('dedupes display-name wrappers on the bare address', () => {
+    expect(mergeBcc('me@example.com', 'Me <me@example.com>')).toBe('Me <me@example.com>');
+  });
+});
+
+describe('account tools defaultBcc override', () => {
+  let addAccountHandler: Function;
+  let updateAccountHandler: Function;
+
+  const mockServer = {
+    registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+      if (name === 'imap_add_account') addAccountHandler = handler;
+      if (name === 'imap_update_account') updateAccountHandler = handler;
+    }),
+  };
+
+  const mockAccountManager = {
+    addAccount: vi.fn(async (acc: any) => ({ ...acc, id: 'acc1' })),
+    getAccount: vi.fn(() => ({ id: 'acc1', name: 'Test', host: 'imap.example.com' })),
+    updateAccount: vi.fn(async (id: string, updates: any) => ({ id, name: 'Test', ...updates })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    accountTools(
+      mockServer as any,
+      mockAccountManager as any,
+      {} as any,
+      { disconnect: vi.fn() } as any,
+    );
+  });
+
+  it('imap_add_account stores a defaultBcc override', async () => {
+    await addAccountHandler({
+      name: 'Test',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: 'pw',
+      tls: true,
+      defaultBcc: 'me@example.com',
+    });
+
+    expect(mockAccountManager.addAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultBcc: 'me@example.com' }),
+    );
+  });
+
+  it('imap_add_account omits defaultBcc when not provided', async () => {
+    await addAccountHandler({
+      name: 'Test',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: 'pw',
+      tls: true,
+    });
+
+    const stored = mockAccountManager.addAccount.mock.calls[0][0];
+    expect('defaultBcc' in stored).toBe(false);
+  });
+
+  it('imap_add_account omits defaultBcc when passed an empty string', async () => {
+    await addAccountHandler({
+      name: 'Test',
+      host: 'imap.example.com',
+      port: 993,
+      user: 'user@example.com',
+      password: 'pw',
+      tls: true,
+      defaultBcc: '',
+    });
+
+    const stored = mockAccountManager.addAccount.mock.calls[0][0];
+    expect('defaultBcc' in stored).toBe(false);
+  });
+
+  it('imap_update_account sets a defaultBcc override', async () => {
+    await updateAccountHandler({ accountId: 'acc1', defaultBcc: 'archive@example.com' });
+
+    expect(mockAccountManager.updateAccount).toHaveBeenCalledWith(
+      'acc1',
+      expect.objectContaining({ defaultBcc: 'archive@example.com' }),
+    );
+  });
+
+  it('imap_update_account clears the override when given an empty string', async () => {
+    await updateAccountHandler({ accountId: 'acc1', defaultBcc: '' });
+
+    const updates = mockAccountManager.updateAccount.mock.calls[0][1];
+    expect('defaultBcc' in updates).toBe(true);
+    expect(updates.defaultBcc).toBeUndefined();
+  });
+
+  it('imap_update_account leaves defaultBcc untouched when not provided', async () => {
+    await updateAccountHandler({ accountId: 'acc1', name: 'Renamed' });
+
+    const updates = mockAccountManager.updateAccount.mock.calls[0][1];
+    expect('defaultBcc' in updates).toBe(false);
+  });
+});
+
+describe('imap_send_email defaultBcc', () => {
+  let sendEmailHandler: Function;
+
+  const mockServer = {
+    registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+      if (name === 'imap_send_email') sendEmailHandler = handler;
+    }),
+  };
+
+  const account: any = {
+    id: 'acc1',
+    name: 'Test',
+    email: 'user@example.com',
+    user: 'user@example.com',
+    defaultBcc: 'archive@example.com',
+    saveToSent: false,
+  };
+
+  const mockSmtpService = {
+    sendEmail: vi.fn(async () => ({ messageId: '<msg-1@example.com>', rawMessage: 'RAW' })),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emailTools(
+      mockServer as any,
+      { appendToSentFolder: vi.fn() } as any,
+      {
+        resolveAccountId: (id: string) => id,
+        getAccount: vi.fn(async () => account),
+      } as any,
+      mockSmtpService as any,
+    );
+  });
+
+  it('injects defaultBcc when the call omits bcc', async () => {
+    await sendEmailHandler({
+      accountId: 'acc1',
+      to: 'rcpt@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+    });
+
+    expect(mockSmtpService.sendEmail).toHaveBeenCalledWith(
+      'acc1',
+      account,
+      expect.objectContaining({ bcc: 'archive@example.com' }),
+    );
+  });
+
+  it('merges call-site bcc with the account default', async () => {
+    await sendEmailHandler({
+      accountId: 'acc1',
+      to: 'rcpt@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+      bcc: 'extra@example.com',
+    });
+
+    expect(mockSmtpService.sendEmail).toHaveBeenCalledWith(
+      'acc1',
+      account,
+      expect.objectContaining({
+        bcc: ['extra@example.com', 'archive@example.com'],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

Set a BCC once on the account (e.g. your own inbox as an archive copy). Every send, reply, forward, and draft then includes it automatically — no need to pass `bcc` on every tool call. Call-site `bcc` still works and is merged in.

## Summary

- New optional `defaultBcc` on `ImapAccount` (`string | string[]`)
- Configure via `imap_add_account` / `imap_update_account` (empty string / empty array clears) and the web wizard POST/PUT routes
- Applied on `imap_send_email`, `imap_save_draft`, `imap_reply_to_email`, `imap_forward_email`
- Reply/forward gain an optional `bcc` parameter (additive, non-breaking)
- Merge helper: explicit addresses first, then defaults; case-insensitive dedupe on the bare address (display-name wrappers supported)
- Tool descriptions mention the auto-BCC behavior the same way Sent-copy is already described
- README + unit tests (merge helper, account CRUD plumbing, send path)

## Use case

MCP clients often send mail on behalf of a shared mailbox and want a private copy of everything that went out. Passing `bcc` on every call is easy to forget — especially on reply/forward, which previously had no `bcc` field. An account-level default fixes that once.

## Implementation background

This follows the same account-override pattern as `sentFolder` / `saveToSent` (#126):

| Concern | `sentFolder` (existing) | `defaultBcc` (this PR) |
|---|---|---|
| Storage | optional field on `ImapAccount` | same |
| Configure | add / update account + web routes | same |
| Clear | empty string on update | empty string or empty array on update |
| Apply where | tool handlers before IMAP append | tool handlers before SMTP compose/send |
| Service layer | stays dumb (`appendToSentFolder` takes override) | stays dumb (`SmtpService` still just sends `email.bcc`) |
| List accounts | not exposed (curated whitelist) | not exposed (same) |

Policy lives in the tool handlers, not in `SmtpService`, matching how Sent-copy policy is applied via `saveSentCopy` rather than inside the IMAP append internals.

Shared pieces mirror existing email-tools helpers:

- `resolveBcc(account, explicit)` — like `saveSentCopy` / `buildAttachments`
- `bccSchema` — like `attachmentSchema`, keeps wording in sync across send/draft/reply/forward

## API surface

**Account tools**
- `imap_add_account.defaultBcc` (optional)
- `imap_update_account.defaultBcc` (optional; `""` or `[]` clears)

**Outbound tools**
- Existing `bcc` on send/draft now documents merge behavior
- New optional `bcc` on reply/forward
- When `defaultBcc` is set, it is always included (merged)

**Web**
- POST `/api/accounts` and PUT `/api/accounts/:id` accept `defaultBcc` with the same empty-clear semantics

## Test plan

- [x] `npm test -- tests/default-bcc.test.ts` (13 tests)
- [x] `npm run lint`
- [x] Manually: set `defaultBcc` via `imap_update_account`, send without `bcc`, confirm archive address receives a copy
- [x] Manually: send with a different `bcc`, confirm both addresses and no duplicate when the same address is passed twice with different casing
- [x] Manually: clear with empty string, confirm subsequent send has no default BCC
- [x] Manually: reply/forward with and without call-site `bcc`


Made with [Cursor](https://cursor.com)