### PR TITLE
fix(security): clear all open dependency advisories (npm audit 0 vulns)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@types/nodemailer": "^8.0.1",
         "body-parser": "^2.2.0",
         "chalk": "^5.4.1",
@@ -584,12 +584,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -630,12 +630,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2063,16 +2063,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2713,9 +2713,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2922,9 +2922,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.25",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3067,9 +3067,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4205,9 +4205,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4225,7 +4225,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@types/nodemailer": "^8.0.1",
     "body-parser": "^2.2.0",
     "chalk": "^5.4.1",
@@ -88,7 +88,12 @@
   },
   "overrides": {
     "qs": "^6.15.2",
-    "hono": "^4.12.25",
+    "hono": "^4.13.0",
+    "@hono/node-server": "^2.0.5",
+    "fast-uri": "^3.1.4",
+    "ip-address": "^10.4.0",
+    "brace-expansion": "^5.0.9",
+    "postcss": "^8.5.23",
     "string-width": "^7.2.0"
   }
 }


### PR DESCRIPTION
## Warum

Der `security`-Job in CI läuft `npm audit --audit-level=high` und **schlägt auf `main` selbst fehl**. Dadurch war jeder offene PR rot — unabhängig vom Inhalt. Dieser PR macht `main` wieder grün und entblockt damit #143, #135, #132 und die Dependabot-PRs.

## Was

Behebt 9 offene Dependabot-Alerts (2 high, 7 medium) plus die dev-scope Findings zu `brace-expansion` und `postcss`. Alle Findings sind **transitiv** — keine Änderung an `src/`.

| Paket | von → nach | Severity | Kern |
|---|---|---|---|
| `@modelcontextprotocol/sdk` | `^1.26.0` → `^1.30.0` | — | öffnet `@hono/node-server` auf `^1.19.9 \|\| ^2.0.5` |
| `hono` | `^4.12.25` → `^4.13.0` | medium ×4 | CORS-ReDoS, jsx cross-request context leak, `cx()`-XSS, Header-De-Dup |
| `@hono/node-server` | `1.19.x` → `^2.0.5` | medium | Path traversal in `serve-static` (Windows, `%5C`) |
| `fast-uri` | `3.1.2` → `^3.1.4` | **high** | Host confusion via Backslash-Authority / IDN |
| `ip-address` | `10.2.0` → `^10.4.0` | **high** | SSRF-Bypass: oktale Oktette, CIDR-Suffix, NAT64 |
| `brace-expansion` | `5.0.6` → `^5.0.9` | high (dev) | DoS via unbounded intermediate arrays |
| `postcss` | `8.5.18` → `^8.5.23` | medium (dev) | beliebiger `.map`-Read via `sourceMappingURL` |

Der SDK-Bump ist die Voraussetzung für den `@hono/node-server`-2.x-Override: erst `1.30.0` akzeptiert die Range.

## Lockfile

Regeneriert in einem Linux-`node:24`-Container, nicht auf macOS — ein macOS-Lockfile lässt die top-level `@emnapi/*`-Einträge weg, woran `npm ci` auf den Runnern scheitert.

## Verifiziert

- `npm audit` → **found 0 vulnerabilities** (vorher: 3 high, 4 moderate)
- `npm ci --dry-run` in `node:24` → sauber
- `npm run build` → ok
- `npm test` → 255/255 grün
- `npm run lint` (`tsc --noEmit`) → sauber

## Ersetzt

Macht die Dependabot-PRs #131 (fast-uri), #139 (ip-address) und #140 (hono) überflüssig — Dependabot kann auf diesem Repo ohnehin nicht rebasen (vitest-4 wasm-Bindings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)