### PR TITLE
fix(imap): fetch latest emails by sequence range instead of SEARCH (#138)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ npm run setup        # launch the web setup wizard
 ```
 
 Always run `npm run build` **and** `npm test` before committing changes that
-touch `src/`. Keep the suite green (currently 342 tests).
+touch `src/`. Keep the suite green (currently 350 tests).
 
 > Note: `npm run lint` (`tsc --noEmit`) is memory-hungry on this project — the
 > MCP SDK's `registerTool` generics are deep enough to surface a pre-existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `imap_get_latest_emails` no longer depends on IMAP SEARCH (#138). Opening a mailbox already reports how many messages it holds, and IMAP orders sequence numbers by arrival — so the newest `count` messages are just the tail of that range. The tool used to call `client.search({ all: true })` first and return `[]` whenever that came back empty, which is what a Strato mailbox does despite reporting a non-zero message count via STATUS. Fetching the tail by sequence number instead removes one round-trip on every call and makes the tool independent of the server's SEARCH behavior. The SEARCH path is kept as a fallback for the case where the mailbox metadata is unavailable. Tests in `tests/imap-service-latest-no-search.test.ts`. Criteria-based `imap_search_emails` still requires SEARCH and is unaffected.
+
 ## [1.6.0] - 2026-08-05
 
 ### Added

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -478,6 +478,39 @@ export class ImapService {
    * Backwards-compatible: when `options` is omitted, the returned shape is
    * identical to the previous version.
    */
+  /**
+   * Address the newest `count` messages of the currently open mailbox.
+   *
+   * Preferred form is a sequence-number range derived from EXISTS, which the
+   * server already reported when the mailbox was selected. Some servers answer
+   * SEARCH with an empty set even though EXISTS is non-zero (#138), which used
+   * to make every read path here come back empty.
+   *
+   * Returns `null` when the mailbox is genuinely empty, or the SEARCH-derived
+   * UID list when the mailbox metadata is unavailable for some reason.
+   */
+  private async latestMessageRange(
+    client: any,
+    count: number,
+  ): Promise<{ value: any; options: any } | null> {
+    const exists = Number(client.mailbox?.exists);
+
+    if (Number.isFinite(exists)) {
+      if (exists <= 0) {
+        return null;
+      }
+      const first = Math.max(1, exists - count + 1);
+      // No `uid: true` here — this is a sequence-number range.
+      return { value: `${first}:${exists}`, options: {} };
+    }
+
+    const uids = await client.search({ all: true }, { uid: true });
+    if (!uids || uids.length === 0) {
+      return null;
+    }
+    return { value: [...uids].sort((a: number, b: number) => a - b).slice(-count), options: { uid: true } };
+  }
+
   async getLatestEmails(
     accountId: string,
     folderName: string,
@@ -492,13 +525,6 @@ export class ImapService {
     try {
       lock = await client.getMailboxLock(folderName);
 
-      const uids = await client.search({ all: true }, { uid: true });
-      if (!uids || uids.length === 0) {
-        return [];
-      }
-
-      const latestUids = [...uids].sort((a, b) => a - b).slice(-count);
-
       const fetchQuery: any = {
         uid: true,
         envelope: true,
@@ -507,9 +533,20 @@ export class ImapService {
         ...(includeBody ? { source: true } : {}),
       };
 
+      // Opening the mailbox already told us how many messages it holds, and
+      // IMAP orders sequence numbers by arrival — so the newest `count`
+      // messages are simply the tail of that range. Fetching them by sequence
+      // number needs no SEARCH at all: one round-trip fewer, and immune to
+      // servers that answer SEARCH with nothing despite a non-zero EXISTS
+      // (#138). Falls back to SEARCH only if the mailbox metadata is missing.
+      const range = await this.latestMessageRange(client, count);
+      if (range === null) {
+        return [];
+      }
+
       const messages: EmailMessage[] = [];
 
-      for await (const msg of client.fetch(latestUids, fetchQuery, { uid: true })) {
+      for await (const msg of client.fetch(range.value, fetchQuery, range.options)) {
         const flags = Array.from(msg.flags || []) as string[];
         const base: EmailMessage = {
           uid: msg.uid,

--- a/tests/imap-service-latest-no-search.test.ts
+++ b/tests/imap-service-latest-no-search.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ImapService } from '../src/services/imap-service.js';
+
+// Minimal imapflow stand-in. `mailbox` mirrors what mailboxOpen() sets once a
+// mailbox is selected — imapflow reports the message count as `exists`.
+const makeClient = (overrides: Record<string, any> = {}) => {
+  const messages = [
+    { uid: 101, seq: 1, internalDate: new Date('2026-01-01'), flags: new Set(['\\Seen']), envelope: { subject: 'first', from: [], to: [] } },
+    { uid: 102, seq: 2, internalDate: new Date('2026-01-02'), flags: new Set(), envelope: { subject: 'second', from: [], to: [] } },
+    { uid: 103, seq: 3, internalDate: new Date('2026-01-03'), flags: new Set(), envelope: { subject: 'third', from: [], to: [] } },
+  ];
+
+  return {
+    mailbox: { path: 'INBOX', exists: 3, uidNext: 104, uidValidity: 1n, flags: new Set() },
+    getMailboxLock: vi.fn(async () => ({ release: vi.fn() })),
+    // A Strato-style server: SEARCH comes back empty even though EXISTS is 3.
+    search: vi.fn(async () => []),
+    fetch: vi.fn(function* () { yield* messages; }),
+    ...overrides,
+  };
+};
+
+const serviceWith = (client: any) => {
+  const service = new ImapService({} as any);
+  // ensureConnected is private; stub it so the test drives the fetch logic only.
+  (service as any).ensureConnected = vi.fn(async () => client);
+  return service;
+};
+
+describe('getLatestEmails without SEARCH (#138)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // The regression: every read path went through client.search({all:true}), so
+  // a server whose SEARCH answers empty made the tool return nothing at all,
+  // even with a non-zero message count.
+  it('returns messages when SEARCH answers empty but EXISTS is non-zero', async () => {
+    const client = makeClient();
+    const messages = await serviceWith(client).getLatestEmails('acc1', 'INBOX', 10);
+
+    expect(messages).toHaveLength(3);
+    expect(client.search).not.toHaveBeenCalled();
+  });
+
+  it('addresses the newest messages by sequence range, not by UID', async () => {
+    const client = makeClient();
+    await serviceWith(client).getLatestEmails('acc1', 'INBOX', 2);
+
+    const [range, , options] = client.fetch.mock.calls[0];
+    expect(range).toBe('2:3');
+    expect(options?.uid).toBeFalsy();
+  });
+
+  it('clamps the range to 1 when the mailbox holds fewer messages than requested', async () => {
+    const client = makeClient();
+    await serviceWith(client).getLatestEmails('acc1', 'INBOX', 50);
+
+    expect(client.fetch.mock.calls[0][0]).toBe('1:3');
+  });
+
+  it('returns an empty list for an empty mailbox without fetching', async () => {
+    const client = makeClient({ mailbox: { path: 'INBOX', exists: 0 } });
+    const messages = await serviceWith(client).getLatestEmails('acc1', 'INBOX', 10);
+
+    expect(messages).toEqual([]);
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  // Defensive: if the mailbox metadata is unavailable we still have the old path.
+  it('falls back to SEARCH when the mailbox reports no EXISTS', async () => {
+    const client = makeClient({
+      mailbox: false,
+      search: vi.fn(async () => [101, 102, 103]),
+    });
+    const messages = await serviceWith(client).getLatestEmails('acc1', 'INBOX', 2);
+
+    expect(client.search).toHaveBeenCalled();
+    const [uids, , options] = client.fetch.mock.calls[0];
+    expect(uids).toEqual([102, 103]);
+    expect(options?.uid).toBe(true);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty when the mailbox metadata is missing and SEARCH is also empty', async () => {
+    const client = makeClient({ mailbox: false, search: vi.fn(async () => []) });
+    expect(await serviceWith(client).getLatestEmails('acc1', 'INBOX', 10)).toEqual([]);
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it('still sorts the result newest first', async () => {
+    const client = makeClient();
+    const messages = await serviceWith(client).getLatestEmails('acc1', 'INBOX', 10);
+
+    expect(messages.map(m => m.subject)).toEqual(['third', 'second', 'first']);
+  });
+
+  it('releases the mailbox lock', async () => {
+    const release = vi.fn();
+    const client = makeClient({ getMailboxLock: vi.fn(async () => ({ release })) });
+    await serviceWith(client).getLatestEmails('acc1', 'INBOX', 10);
+
+    expect(release).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Behebt die Lesepfade aus #138.

## Problem

`getLatestEmails` öffnet die Mailbox und fragt dann **SEARCH** nach allen UIDs — und gibt `[]` zurück, wenn das leer kommt:

```ts
const uids = await client.search({ all: true }, { uid: true });
if (!uids || uids.length === 0) return [];
```

Gegen Strato antwortet SEARCH leer, obwohl STATUS 21 Nachrichten meldet. Damit kommt `imap_get_latest_emails` mit nichts zurück.

Die Bruchlinie ist im Code sichtbar:

| Pfad | IMAP-Kommandos | Ergebnis beim Melder |
|---|---|---|
| `imap_test_account` | **STATUS** | `messageCount: 21` ✅ |
| jeder Lesepfad | **SELECT + SEARCH** | leer ❌ |

## Fix

Das Öffnen der Mailbox liefert bereits `EXISTS`, und IMAP ordnet Sequenznummern nach Eingang — die neuesten `count` Nachrichten sind also schlicht das Ende von `1..EXISTS`. Dafür braucht es kein SEARCH:

```ts
const first = Math.max(1, exists - count + 1);
return { value: `${first}:${exists}`, options: {} };   // Sequenznummern, keine UIDs
```

Das ist unabhängig von Strato eine Verbesserung: **ein Round-Trip weniger bei jedem Aufruf, bei jedem Provider**, und das Ergebnis hängt nicht mehr davon ab, wie der Server SEARCH implementiert.

Der SEARCH-Pfad bleibt als Fallback, falls die Mailbox-Metadaten fehlen — es regressiert also nichts bei Servern, die kein `EXISTS` melden.

## Ehrliche Einordnung

Das ist eine **Ableitung aus den Codepfaden, keine Reproduktion**. Ich habe keinen Strato-Zugang. Belegt ist: STATUS funktioniert beim Melder, alle Lesepfade laufen über `client.search`, und beide Symptome passen exakt zusammen. Ob Strato wirklich an SEARCH scheitert, bestätigt erst der Melder.

Die kriteriengestützte `imap_search_emails` **braucht** SEARCH und bleibt unangetastet — #138 bleibt für diese Hälfte offen.

## Tests

`tests/imap-service-latest-no-search.test.ts`, 8 Fälle. Der zentrale stellt das Strato-Szenario nach: `search → []` bei `exists: 3`.

Gegenprobe: **4 der 8 scheitern gegen die alte Implementierung** — genau die, die das Szenario abbilden. Die übrigen 4 decken Fallback- und Leer-Pfad ab, die sich nicht geändert haben.

## Verifiziert

- `npm run build` ok
- `npm test` → **350/350**
- `npm run lint` (`tsc --noEmit`) sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)