### PR TITLE
chore: raise the Node floor to 22.12 and guard it against the dep tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        # Must stay within package.json's engines.node (>=22.12).
+        # tests/node-engines.test.ts guards the floor against the dep tree.
+        node-version: [22.x, 24.x]
       fail-fast: false
 
     steps:
@@ -43,7 +45,7 @@ jobs:
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v7
-        if: matrix.node-version == '20.x'
+        if: matrix.node-version == '22.x'
         with:
           name: coverage-report
           path: coverage/
@@ -79,7 +81,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies
@@ -112,7 +114,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ npm run setup        # launch the web setup wizard
 ```
 
 Always run `npm run build` **and** `npm test` before committing changes that
-touch `src/`. Keep the suite green (currently 350 tests).
+touch `src/`. Keep the suite green (currently 353 tests).
 
 > Note: `npm run lint` (`tsc --noEmit`) is memory-hungry on this project — the
 > MCP SDK's `registerTool` generics are deep enough to surface a pre-existing
@@ -85,7 +85,15 @@ touch `src/`. Keep the suite green (currently 350 tests).
 
 ## Conventions
 
-- TypeScript, ESM (`"type": "module"`), Node ≥ 18.
+- TypeScript, ESM (`"type": "module"`), **Node ≥ 22.12** (declared in
+  `package.json` `engines.node`; CI runs 22.x and 24.x).
+  - npm checks a dependency's `engines` against the Node doing the *install*,
+    not against the floor we declare — so a dependency needing a newer Node
+    installs silently and only breaks on a user's older runtime. This is how
+    #108 happened. `tests/node-engines.test.ts` walks the runtime dependency
+    tree and fails if any package needs more than we advertise. When it fires,
+    either raise the floor (CI matrix, AGENTS.md and README with it) or pin the
+    package back via npm `overrides`.
 - Tool names are stable public API: `imap_*`. Do not rename without a strong
   reason and a migration note.
 - Zod schemas describe every tool input; every field gets a `.describe()` that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Minimum supported Node.js is now 22.12** (previously documented as 18). This formalizes what the dependency tree already required: 11 runtime packages exclude Node 18, and `commander@15` needs >=22.12 — while CI still tested on 20.x. Node 18 and 20 are both end-of-life. `package.json` now declares `engines.node`, the CI matrix moves to 22.x/24.x, and `tests/node-engines.test.ts` walks the runtime tree and fails if any dependency needs a newer Node than we advertise — npm does not check this itself, since it validates a dependency's `engines` against the installing Node rather than against our declared floor. That gap is how #108 reached users.
+
 ### Fixed
 - `imap_get_latest_emails` no longer depends on IMAP SEARCH (#138). Opening a mailbox already reports how many messages it holds, and IMAP orders sequence numbers by arrival — so the newest `count` messages are just the tail of that range. The tool used to call `client.search({ all: true })` first and return `[]` whenever that came back empty, which is what a Strato mailbox does despite reporting a non-zero message count via STATUS. Fetching the tail by sequence number instead removes one round-trip on every call and makes the tool independent of the server's SEARCH behavior. The SEARCH path is kept as a fallback for the case where the mailbox metadata is unavailable. Tests in `tests/imap-service-latest-no-search.test.ts`. Criteria-based `imap_search_emails` still requires SEARCH and is unaffected.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ A powerful Model Context Protocol (MCP) server that provides seamless IMAP email
 
 ## Installation
 
+> **Requires Node.js 22.12 or newer.** Node 18 and 20 have both reached
+> end-of-life, and several of this package's dependencies no longer support
+> them. Check yours with `node --version`.
+
 ### Run via npx (No Installation Required)
 
 Once published to npm, you can run the server directly without cloning or building anything — `npx` downloads the prebuilt package and runs it:

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,13 @@
         "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "^0.28.1",
         "nodemon": "^3.1.10",
+        "semver": "^7.8.4",
         "tsx": "^4.20.3",
         "typescript": "^7.0.2",
         "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -764,9 +768,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,9 +783,6 @@
       "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -802,9 +800,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,9 +816,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -839,9 +831,6 @@
       "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -996,9 +985,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,9 +1002,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1036,9 +1019,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,9 +1036,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,9 +1053,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1096,9 +1070,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3484,9 +3455,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3508,9 +3476,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3532,9 +3497,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3556,9 +3518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
   },
   "homepage": "https://github.com/nikolausm/imap-mcp-server#readme",
   "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
@@ -63,6 +66,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.28.1",
     "nodemon": "^3.1.10",
+    "semver": "^7.8.4",
     "tsx": "^4.20.3",
     "typescript": "^7.0.2",
     "vitest": "^4.1.8"

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -3,10 +3,15 @@ import { readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 // Regression guard for #108: `string-width` 8.x uses the regex `v` flag, which
-// throws "Invalid regular expression flags" on Node <20. AGENTS.md promises
-// Node >=18 support, so any transitive upgrade to 8.x silently breaks the
-// `imap-setup` entrypoint for older Node installs. Pin via npm `overrides` and
-// assert no copy of 8.x ships under node_modules.
+// throws "Invalid regular expression flags" on Node <20, and a transitive
+// upgrade to 8.x silently broke the `imap-setup` entrypoint. Pinned via npm
+// `overrides`; this asserts no copy of 8.x ships under node_modules.
+//
+// Note: the original Node-18 rationale is obsolete now that the floor is 22.12
+// (see tests/node-engines.test.ts, which generalizes this check to the whole
+// runtime tree). The pin is kept because dropping it is a dependency change
+// with no upside, not because 8.x is still dangerous — it can go the next time
+// this area is touched.
 
 const ROOT = join(process.cwd(), 'node_modules');
 const SEMVER_8X = /^8\./;

--- a/tests/node-engines.test.ts
+++ b/tests/node-engines.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import semver from 'semver';
+
+// Keeps the Node floor we advertise honest.
+//
+// npm does NOT check a dependency's `engines` against the floor declared here —
+// it checks it against the Node version doing the install. So on a modern
+// machine a dependency that requires a newer Node than we promise installs with
+// no warning at all, and the mismatch only surfaces as a crash on a user's
+// older runtime. That is exactly how #108 happened (`string-width@8` needed
+// Node >=20 while we promised >=18) and how PR #134 (`chalk@6`, Node >=22)
+// would have slipped in unnoticed.
+//
+// This walks the runtime dependency tree from the lockfile and asserts that the
+// Node version in package.json's `engines` actually satisfies every one of
+// them. Dev dependencies are excluded — they only ever run on a maintainer's
+// machine and legitimately require newer runtimes.
+
+const ROOT = process.cwd();
+
+const declaredFloor = (): string => {
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
+  const range = pkg.engines?.node;
+  expect(range, 'package.json must declare engines.node').toBeTruthy();
+  const min = semver.minVersion(range);
+  expect(min, `engines.node "${range}" has no resolvable minimum`).toBeTruthy();
+  return min!.version;
+};
+
+/** Every non-dev package in the lockfile, with the `engines.node` it declares. */
+const runtimeDependencies = (): Array<{ name: string; version: string; engines: string }> => {
+  const lock = JSON.parse(readFileSync(join(ROOT, 'package-lock.json'), 'utf-8'));
+  const found: Array<{ name: string; version: string; engines: string }> = [];
+
+  for (const [path, meta] of Object.entries<any>(lock.packages)) {
+    if (!path || meta.dev) continue;
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(join(ROOT, path, 'package.json'), 'utf-8'));
+    } catch {
+      continue; // optional dependency not installed on this platform
+    }
+    const engines = pkg.engines?.node;
+    if (engines) {
+      found.push({ name: path.replace(/^.*node_modules\//, ''), version: pkg.version, engines });
+    }
+  }
+  return found;
+};
+
+describe('advertised Node floor matches the runtime dependency tree', () => {
+  it('package.json declares engines.node', () => {
+    expect(declaredFloor()).toBeTruthy();
+  });
+
+  it('sanity: the lockfile yields runtime packages that declare engines', () => {
+    expect(runtimeDependencies().length).toBeGreaterThan(10);
+  });
+
+  it('no runtime dependency requires a newer Node than we advertise', () => {
+    const floor = declaredFloor();
+    const violations = runtimeDependencies()
+      .filter(dep => !semver.satisfies(floor, dep.engines, { includePrerelease: true }))
+      .map(dep => `  ${dep.name}@${dep.version} requires node ${dep.engines}`);
+
+    expect(
+      violations,
+      `package.json advertises node >=${floor}, but these runtime dependencies need more:\n` +
+      `${violations.join('\n')}\n\n` +
+      'Either raise engines.node (and the CI matrix, AGENTS.md and README with it),\n' +
+      'or pin the offending package back via npm "overrides".',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Aufgefallen beim Bewerten von #134 (chalk 5→6, verlangt Node ≥ 22). Beim Nachprüfen stellte sich heraus: **die dokumentierte Zusage „Node ≥ 18" stimmt schon länger nicht.**

## Der Befund

11 Runtime-Pakete schließen Node 18 aus, vier davon direkte Abhängigkeiten:

| Paket | verlangt | Node 18 | Node 20 |
|---|---|---|---|
| `commander@15.0.0` | `>=22.12.0` | ✗ | **✗** |
| `open@11.0.0` | `>=20` | ✗ | ✓ |
| `ora@9.4.1` | `>=20` | ✗ | ✓ |
| `pdf-parse@2.4.5` | `>=20.16.0 <21 \|\| >=22.3.0` | ✗ | ✓ |

Dazu sieben transitive (`@hono/node-server`, `html-to-text`, `pdfjs-dist`, `thread-stream`, …).

`commander@15` verlangt **Node ≥ 22.12** – und **CI testete auf 20.x**. Der Job lief nur durch, weil npms `EBADENGINE` bloß warnt und die Tests die betroffenen Pfade nicht anfassen.

Node 18 ist seit April 2025 EOL, Node 20 seit April 2026. Statt vier Major-Downgrades zu machen, um eine Zusage zu halten, auf die sich ohnehin niemand verlassen kann, wird der Floor auf das angehoben, was der Baum längst verlangt.

## Änderungen

- `package.json` deklariert `engines.node: ">=22.12.0"` – bisher **gar kein** `engines`-Feld
- CI-Matrix `20.x/22.x` → `22.x/24.x`; Build-, Lint- und Security-Job ebenfalls weg von Node 20
- Die Coverage-Upload-Bedingung hing auf `'20.x'` und hätte nach dem Matrix-Wechsel **nie wieder ausgelöst** – zieht jetzt mit
- README nennt die Anforderung; bisher stand dort überhaupt keine Node-Version

## Der eigentliche Punkt: der Guard

**npm prüft die `engines` einer Abhängigkeit gegen die Node-Version, die installiert – nicht gegen den Floor, den wir deklarieren.** Ein `engines`-Feld allein hätte den chalk-Bump also *nicht* gefangen; das habe ich nachgemessen. Eine Abhängigkeit, die neueres Node braucht, installiert sich lautlos und bricht erst auf dem älteren Runtime eines Nutzers.

Genau so ist **#108** zu den Nutzern gelangt (`string-width@8` brauchte Node ≥ 20, versprochen war ≥ 18), und genau so wäre **#134** unbemerkt durchgerutscht.

`tests/node-engines.test.ts` läuft den Runtime-Baum aus dem Lockfile ab und scheitert, wenn ein Paket mehr verlangt als wir zusagen – mit Namen und beiden Auswegen. Dev-Dependencies sind ausgenommen, die laufen nur auf Maintainer-Rechnern.

Gegenprobe, Floor testweise auf `>=18` zurückgesetzt:

```
AssertionError: package.json advertises node >=18.0.0, but these runtime
dependencies need more:
  commander@15.0.0 requires node >=22.12.0
  open@11.0.0 requires node >=20
  ora@9.4.1 requires node >=20
  ... (12 insgesamt)

Either raise engines.node (and the CI matrix, AGENTS.md and README with it),
or pin the offending package back via npm "overrides".
```

`semver` wird explizite devDependency – es war bisher nur transitiv über `nodemon` und den vitest-Coverage-Reporter da, zu wackelig für einen Guard.

Der bestehende `string-width`-Pin behält seinen Test; seine Node-18-Begründung ist jetzt hinfällig, was der Kommentar festhält.

## Breaking Change

Für Nutzer auf Node 18 oder 20 ist das formal ein Bruch. Faktisch bestand er schon – er war nur nicht deklariert. Gehört in einen **Minor**-Release mit deutlichem Hinweis, nicht in einen Patch.

## Folge für #134

Danach unproblematisch: `chalk@6` verlangt `>=22`, also **weniger** als das bereits installierte `commander@15`. Kann nach diesem PR gemergt werden.

## Verifiziert

- `npm ci --dry-run` in `node:24` sauber
- `npm audit` → 0 Vulnerabilities
- Build ok, **353/353 Tests**, `tsc --noEmit` sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)