### PR TITLE
fix: keep Bcc headers in draft and Sent MIME copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `imap_save_draft` and Sent-folder copies now keep `Bcc` headers in the stored MIME. Nodemailer's `MailComposer` omits Bcc from the built message by default (SMTP envelope only), so even when `defaultBcc` / a call-site `bcc` was merged into the composer, the appended draft or Sent copy had no `Bcc:` line and mail clients showed an empty BCC field. `SmtpService.composeRaw` now sets `keepBcc` on the compiled message. SMTP delivery was already correct; only the IMAP-stored copy was missing the header. Tests in `tests/smtp-service-compose-raw-bcc.test.ts`.
+
 ## [2.0.0] - 2026-08-05
 
 Major only because of the Node requirement. **No tool was renamed, and no tool's

--- a/README.md
+++ b/README.md
@@ -564,7 +564,8 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
 
   When the account has `defaultBcc` configured, those address(es) are always
   BCC'd on send, reply, forward, and draft (merged with any per-call `bcc`;
-  duplicates removed case-insensitively).
+  duplicates removed case-insensitively). The Bcc header is kept in the MIME
+  stored for drafts and Sent-folder copies so mail clients show it.
 
 - **imap_save_draft**: Save an email as a draft (no send). Takes the same fields as `imap_send_email`, plus `inReplyTo`, `references`, and an optional `folder` override for the Drafts folder.
 

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -146,9 +146,13 @@ export class SmtpService {
   }
 
   // Build the raw RFC 822 message without sending. Used for drafts and Sent-folder copies.
+  // keepBcc is required: MailComposer omits Bcc from the MIME by default (SMTP
+  // envelope-only). Without it, imap_save_draft and Sent-folder copies drop
+  // Bcc even when resolveBcc / defaultBcc injected recipients into email.bcc.
   async composeRaw(account: ImapAccount, email: EmailComposer): Promise<Buffer> {
-    const compiled = new MailComposer(this.toMailOptions(account, email));
-    return compiled.compile().build();
+    const message = new MailComposer(this.toMailOptions(account, email)).compile();
+    message.keepBcc = true;
+    return message.build();
   }
 
   async sendEmail(accountId: string, account: ImapAccount, email: EmailComposer): Promise<{ messageId: string; rawMessage?: Buffer }> {

--- a/tests/smtp-service-compose-raw-bcc.test.ts
+++ b/tests/smtp-service-compose-raw-bcc.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { SmtpService } from '../src/services/smtp-service.js';
+import type { ImapAccount } from '../src/types/index.js';
+
+/**
+ * MailComposer strips Bcc from built MIME unless keepBcc is set. Drafts and
+ * Sent-folder copies go through composeRaw, so without keepBcc the Bcc header
+ * promised by defaultBcc (#143) never appears in the stored message.
+ */
+const account: ImapAccount = {
+  id: 'acc1',
+  name: 'Test',
+  host: 'imap.example.com',
+  port: 993,
+  user: 'user@example.com',
+  password: 'pw',
+  tls: true,
+  email: 'user@example.com',
+};
+
+const headerOf = (raw: string, name: string) => {
+  const headers = raw.split(/\r?\n\r?\n/)[0].split(/\r?\n/);
+  const start = headers.findIndex(line => line.startsWith(`${name}: `));
+  if (start === -1) return '';
+  const folded = [headers[start]];
+  for (let i = start + 1; i < headers.length && /^[ \t]/.test(headers[i]); i++) {
+    folded.push(headers[i].trim());
+  }
+  return folded.join(' ').slice(name.length + 2);
+};
+
+describe('SmtpService.composeRaw keepBcc', () => {
+  const smtp = new SmtpService();
+
+  it('includes a Bcc header in the raw MIME when bcc is set', async () => {
+    const raw = await smtp.composeRaw(account, {
+      from: 'user@example.com',
+      to: 'rcpt@example.com',
+      bcc: 'archive@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+    });
+
+    expect(headerOf(raw.toString(), 'Bcc')).toBe('archive@example.com');
+  });
+
+  it('includes every address when bcc is an array', async () => {
+    const raw = await smtp.composeRaw(account, {
+      from: 'user@example.com',
+      to: 'rcpt@example.com',
+      bcc: ['archive@example.com', 'copy@example.com'],
+      subject: 'Hi',
+      text: 'Hello',
+    });
+
+    const bcc = headerOf(raw.toString(), 'Bcc');
+    expect(bcc).toContain('archive@example.com');
+    expect(bcc).toContain('copy@example.com');
+  });
+
+  it('omits Bcc when no bcc recipients are set', async () => {
+    const raw = await smtp.composeRaw(account, {
+      from: 'user@example.com',
+      to: 'rcpt@example.com',
+      subject: 'Hi',
+      text: 'Hello',
+    });
+
+    expect(headerOf(raw.toString(), 'Bcc')).toBe('');
+    expect(raw.toString()).not.toMatch(/^Bcc:/im);
+  });
+});


### PR DESCRIPTION
## TL;DR

Drafts and Sent copies now keep the `Bcc:` header in the stored MIME. Before this, `defaultBcc` / call-site `bcc` worked for SMTP delivery but mail clients showed an empty BCC on drafts.

## Summary

- `SmtpService.composeRaw` sets `keepBcc = true` on the compiled MailComposer message
- Nodemailer otherwise strips Bcc from built MIME (envelope-only for SMTP)
- Affects `imap_save_draft` and Sent-folder copies built from the same raw message
- Tests in `tests/smtp-service-compose-raw-bcc.test.ts`
- CHANGELOG + README note

## Background

Follow-up to #143 (`defaultBcc`). After merging that, drafts created via MCP still looked like they had no BCC in Apple Mail / WorkMail. Root cause: `composeRaw` used `MailComposer(...).compile().build()` without `keepBcc`, so the header never made it into the IMAP APPEND payload. SMTP `sendMail` was fine because nodemailer puts BCC on the envelope separately.

## Test plan

- [x] `npm test` (356 tests)
- [x] `npm run build`
- [x] `npm run lint`
- [x] Manually: set `defaultBcc`, `imap_save_draft` without call-site `bcc`, open draft in a client and confirm BCC is visible
- [x] Manually: send with `defaultBcc`, confirm Sent copy also shows BCC
