### PR TITLE
fix(security): override html-to-text and nanoid to clear audit advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Two dependency advisories cleared — `npm audit` reports 0 vulnerabilities again, with no source changes. `html-to-text` → `^10.0.1` pulls in `deepmerge-ts` 8.0.1 (GHSA-ggr8-5vv4-36mx, stack exhaustion when merging recursive object graphs); this is the one that matters, because it sits on a **runtime** path via `mailparser` → `html-to-text`. `mailparser` pins `html-to-text` to exactly `10.0.0`, so the fix cannot arrive on its own — the override deliberately supersedes that pin. Upstream 10.0.1 is a patch whose only change is that same `deepmerge-ts` bump. `nanoid` → `^3.3.18` (GHSA-2v37-7h3g-55p8, custom generators can loop indefinitely when size is zero) is dev-scope only, reached through `vitest` → `vite` → `postcss`.
+
+  As in #144, the CI `security` job (`npm audit --audit-level=high`) had started failing on `main` itself, which turns every open pull request red regardless of its content and blocks `dependabot-auto-merge.yml`.
+
 ## [2.0.0] - 2026-08-05
 
 Major only because of the Node requirement. **No tool was renamed, and no tool's

--- a/package-lock.json
+++ b/package-lock.json
@@ -2291,9 +2291,19 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+      "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -2909,13 +2919,13 @@
       "license": "MIT"
     },
     "node_modules/html-to-text": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
-      "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.1.tgz",
+      "integrity": "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==",
       "license": "MIT",
       "dependencies": {
         "@selderee/plugin-htmlparser2": "~0.12.0",
-        "deepmerge-ts": "^7.1.5",
+        "deepmerge-ts": "^8.0.1",
         "dom-serializer": "^2.0.0",
         "htmlparser2": "^10.1.0",
         "selderee": "~0.12.0"
@@ -3770,9 +3780,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "ip-address": "^10.4.0",
     "brace-expansion": "^5.0.9",
     "postcss": "^8.5.23",
-    "string-width": "^7.2.0"
+    "string-width": "^7.2.0",
+    "nanoid": "^3.3.18",
+    "html-to-text": "^10.0.1"
   }
 }


### PR DESCRIPTION
## TL;DR

`npm audit --audit-level=high` is failing on `main` itself again. That turns **every** open pull request red regardless of its content and blocks `dependabot-auto-merge.yml` — the same failure mode as #144. Two `overrides`, no source changes, `npm audit` back to 0 vulnerabilities.

## The two advisories

| Advisory | Path | Scope |
|---|---|---|
| [GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx) — `deepmerge-ts <8`, stack exhaustion on recursive object graphs | `mailparser` → `html-to-text` → `deepmerge-ts` | **runtime** |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — `nanoid <3.3.18`, custom generators can loop indefinitely when size is zero | `vitest` → `vite` → `postcss` → `nanoid` | dev only |

The `deepmerge-ts` one is the one that matters — it is on a runtime path through `mailparser`, which we use for every message we parse.

## Why an override rather than a version bump

`mailparser@3.9.15` pins `html-to-text` to **exactly `10.0.0`**, with no caret. So the fix cannot arrive through a normal dependency bump, not even via Dependabot — #154 bumps `mailparser` to 3.9.15 and still resolves `html-to-text` to 10.0.0. The override deliberately supersedes that pin.

That is worth stating plainly, since overriding an exact pin is the kind of thing that deserves a second look: upstream `html-to-text` 10.0.1 is a patch release whose only change is that same `deepmerge-ts` bump, so the risk is small — but it is a decision, not an automatic update.

`npm audit fix --force` was not an option: it would have rolled `mailparser` back to 3.9.8.

`postcss` is already in `overrides`; `nanoid` just needed to follow it.

## Lockfile

Regenerated in a Linux `node:24` container and validated there with `npm ci --dry-run` (exit 0), so the top-level `@emnapi/*` entries stay intact — a macOS-generated lockfile omits them and breaks `npm ci` on the runners.

The lockfile diff touches exactly three entries: `nanoid` 3.3.16 → 3.3.18, `html-to-text` 10.0.0 → 10.0.1, `deepmerge-ts` 7.1.5 → 8.0.1. No collateral updates.

## Test plan

- [x] `npm audit` — 0 vulnerabilities
- [x] `npm ci --dry-run` in `node:24` — exit 0, no `EUSAGE`
- [x] `npm run build`
- [x] `npm test` — 353 passed
- [x] `npm run lint`

## After this merges

#154 needs `@dependabot rebase` (or `gh pr update-branch 154`) to pick up the overrides — Dependabot PRs do not rebase themselves onto a moved `main`. Its `security` check should then go green and auto-merge can take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
