### PR TITLE
ci: skip claude-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,19 @@ jobs:
     # Fork PRs don't get access to repo secrets or OIDC tokens, so the review
     # action can't authenticate and the job always fails. Skip it for forks;
     # external PRs are still covered by build/lint/security/test.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    #
+    # Dependabot needs the same treatment for the same underlying reason. Its
+    # events resolve secrets from the separate *Dependabot* secret store rather
+    # than the Actions one ("Secret source: Dependabot" in the run log), so
+    # CLAUDE_CODE_OAUTH_TOKEN arrives empty and the action dies within seconds.
+    # Mirroring the token into that store would only spend review budget on
+    # lockfile diffs; dependabot-auto-merge.yml already gates those PRs with the
+    # full test/lint/build/audit suite. Guard on github.actor, not on the PR
+    # author, so a maintainer pushing to a Dependabot branch still gets a review
+    # — that event resolves secrets normally.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## TL;DR

`claude-review` failed within ~8 seconds on every Dependabot PR (#154 most recently). It looks like a broken review workflow, but it's an authentication problem with the **same root cause as the fork guard already sitting in that file**.

## Root cause

Dependabot events resolve secrets from the separate **Dependabot** secret store, not the Actions one. The run log for #154 says it outright:

```
Secret source: Dependabot
```

`CLAUDE_CODE_OAUTH_TOKEN` exists only in the Actions store — `gh secret list --app dependabot` returns nothing. So the action gets an empty token and exits before doing any work. Nothing to do with the PR's content, and no amount of rebasing would have fixed it.

## Why skip rather than mirror the token

Copying the token into the Dependabot store would clear the symptom, but it would spend review budget on lockfile diffs and widen where that credential is reachable. Dependabot PRs are already gated by `dependabot-auto-merge.yml`, which runs the full test / lint / build / audit suite before merging anything — a stricter gate than a review comment.

The guard checks `github.actor`, not the PR author, so a maintainer pushing to a Dependabot branch still gets a review — that event resolves secrets normally.

## What this does not change

- Regular PRs: unaffected.
- Fork PRs: still skipped by the existing condition.
- `auto-merge` failing on #154 is **not** covered here and is not a bug — that job fails at its own `npm audit --audit-level=high` gate, which is exactly what it's meant to do. #155 clears the advisories behind it.

## Verification

`>-` folds to the intended single condition:

```
github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
```

The real end-to-end check is #154 after a rebase: `claude-review` should report *skipped* instead of *failed*.

No CHANGELOG entry — CI-internal, nothing user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
