### PR TITLE
fix(imap): add allowStartTLS opt-out for opportunistic STARTTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,11 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - user: Username
   - password: Password
   - tls: Use TLS/SSL (default: true)
+  - allowStartTLS: When tls is false, set to false to also disable the
+      opportunistic STARTTLS upgrade imapflow otherwise attempts whenever the
+      server advertises it (validating the cert against `host` regardless of
+      `tls`). Needed for providers that advertise STARTTLS on a hostname
+      covered only by a shared/wildcard cert. Defaults to true.
   - sentFolder: Explicit Sent-folder name for sent-mail copies, e.g. "Gesendet"
       (optional — only needed when the server has no \Sent SPECIAL-USE folder
       and auto-detection fails)
@@ -340,7 +345,7 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   ```
   Parameters:
   - accountId: ID of the account to update
-  - name, host, port, user, password, tls, email: IMAP fields (all optional)
+  - name, host, port, user, password, tls, allowStartTLS, email: IMAP fields (all optional)
   - smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword: SMTP fields (optional)
   - saveToSent: Save sent emails to the Sent folder (optional)
   - sentFolder: Explicit Sent-folder override (optional). Pass an empty string

--- a/src/services/imap-service.ts
+++ b/src/services/imap-service.ts
@@ -189,6 +189,13 @@ export class ImapService {
       // check the cert against a default of "localhost" and reject a cert
       // bound to e.g. 127.0.0.1 (local bridges like ProtonMail Bridge).
       tls: { host: account.host },
+      // imapflow opportunistically upgrades a non-`secure` connection via
+      // STARTTLS whenever the server advertises it, independent of `secure`.
+      // That's the desired behavior for the common STARTTLS-on-submission-port
+      // case, but some providers advertise STARTTLS on a hostname covered only
+      // by a shared/wildcard cert that doesn't match — allowStartTLS: false
+      // lets an account opt out and stay on the plain connection.
+      ...(account.allowStartTLS === false ? { doSTARTTLS: false } : {}),
       auth: {
         user: account.user,
         pass: account.password,
@@ -1590,6 +1597,8 @@ export class ImapService {
       secure: account.tls,
       // Validate the certificate against the host we actually dial; see connect().
       tls: { host: account.host },
+      // See connect() — allowStartTLS: false opts out of the opportunistic upgrade.
+      ...(account.allowStartTLS === false ? { doSTARTTLS: false } : {}),
       auth: {
         user: account.user,
         pass: account.password,

--- a/src/tools/account-tools.ts
+++ b/src/tools/account-tools.ts
@@ -20,6 +20,7 @@ export function accountTools(
       user: z.string().describe('Username for authentication'),
       password: z.string().describe('Password for authentication'),
       tls: z.boolean().default(true).describe('Use TLS/SSL (default: true)'),
+      allowStartTLS: z.boolean().optional().describe('When tls is false, imapflow still opportunistically upgrades via STARTTLS if the server advertises it, validating the cert against `host` regardless of `tls`. Set to false to disable that upgrade and stay on the plain connection — needed for providers (e.g. some DreamHost mail hosting) that advertise STARTTLS on a hostname covered only by a shared/wildcard cert. Defaults to true.'),
       email: z.string().optional().describe('Email address (From: header). Defaults to user if omitted'),
       smtpHost: z.string().optional().describe('SMTP server hostname. Defaults to IMAP host with imap.→smtp. rewrite'),
       smtpPort: z.coerce.number().optional().describe('SMTP server port (465 for SMTPS, 587 for STARTTLS). Defaults to 587'),
@@ -27,7 +28,7 @@ export function accountTools(
       sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Only needed when auto-detection fails — the server must lack a \\Sent SPECIAL-USE folder. Check names with imap_list_folders'),
       defaultBcc: z.union([z.string(), z.array(z.string())]).optional().describe('Optional BCC address(es) applied automatically to every outbound send, reply, forward, and draft for this account. Merged with any per-call bcc'),
     }
-  }, async ({ name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, sentFolder, defaultBcc }) => {
+  }, async ({ name, host, port, user, password, tls, allowStartTLS, email, smtpHost, smtpPort, smtpSecure, sentFolder, defaultBcc }) => {
     const smtp = (smtpHost || smtpPort !== undefined || smtpSecure !== undefined)
       ? {
           host: smtpHost || host,
@@ -43,6 +44,7 @@ export function accountTools(
       user,
       password,
       tls,
+      ...(allowStartTLS !== undefined ? { allowStartTLS } : {}),
       ...(email ? { email } : {}),
       ...(smtp ? { smtp } : {}),
       ...(sentFolder ? { sentFolder } : {}),
@@ -74,6 +76,7 @@ export function accountTools(
       user: z.string().optional().describe('IMAP username'),
       password: z.string().optional().describe('New password'),
       tls: z.boolean().optional().describe('Use TLS for IMAP'),
+      allowStartTLS: z.boolean().optional().describe('When tls is false, set to false to also disable imapflow\'s opportunistic STARTTLS upgrade (see imap_add_account). Defaults to true.'),
       email: z.string().optional().describe('Email address (From: header)'),
       smtpHost: z.string().optional().describe('SMTP hostname'),
       smtpPort: z.coerce.number().optional().describe('SMTP port (465 for SMTPS, 587 for STARTTLS)'),
@@ -84,7 +87,7 @@ export function accountTools(
       sentFolder: z.string().optional().describe('Explicit Sent-folder name for saving sent-mail copies (e.g. "Gesendet"). Overrides auto-detection; pass an empty string to clear the override and re-enable auto-detection. Check names with imap_list_folders'),
       defaultBcc: z.union([z.string(), z.array(z.string())]).optional().describe('Optional BCC address(es) applied automatically to every outbound message for this account. Pass an empty string to clear'),
     }
-  }, async ({ accountId, name, host, port, user, password, tls, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent, sentFolder, defaultBcc }) => {
+  }, async ({ accountId, name, host, port, user, password, tls, allowStartTLS, email, smtpHost, smtpPort, smtpSecure, smtpUser, smtpPassword, saveToSent, sentFolder, defaultBcc }) => {
     const existing = accountManager.getAccount(accountId);
     if (!existing) {
       throw new Error(`Account ${accountId} not found`);
@@ -97,6 +100,7 @@ export function accountTools(
     if (user !== undefined) updates.user = user;
     if (password !== undefined) updates.password = password;
     if (tls !== undefined) updates.tls = tls;
+    if (allowStartTLS !== undefined) updates.allowStartTLS = allowStartTLS;
     if (email !== undefined) updates.email = email;
     if (saveToSent !== undefined) updates.saveToSent = saveToSent;
     // Empty string clears the override (falls back to auto-detection).
@@ -160,6 +164,7 @@ export function accountTools(
             port: acc.port,
             user: acc.user,
             tls: acc.tls,
+            ...(acc.allowStartTLS === false ? { allowStartTLS: false } : {}),
           })),
         }, null, 2)
       }]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,15 @@ export interface ImapAccount {
   user: string;
   password: string;
   tls: boolean;
+  /** When `tls` is false, imapflow still opportunistically upgrades via STARTTLS
+   * if the server advertises it, validating the cert against `host` regardless
+   * of the `tls` setting. Some providers (e.g. DreamHost shared mail hosting)
+   * advertise STARTTLS on a hostname covered only by a shared wildcard cert,
+   * so the opportunistic upgrade fails cert validation even though the account
+   * was configured for a plain connection. Set this to `false` to disable the
+   * STARTTLS upgrade attempt entirely and stay on the plain connection.
+   * Defaults to `true` (existing opportunistic-STARTTLS behavior). */
+  allowStartTLS?: boolean;
   email?: string;
   loginMethod?: string;
   authTimeout?: number;

--- a/tests/imap-service-allow-starttls.test.ts
+++ b/tests/imap-service-allow-starttls.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ImapService } from '../src/services/imap-service.js';
+import type { ImapAccount } from '../src/types/index.js';
+
+// Records the options every ImapFlow is constructed with so we can assert on
+// the STARTTLS parameters the service hands to imapflow.
+const constructorOptions: any[] = [];
+
+vi.mock('imapflow', () => ({
+  ImapFlow: class {
+    constructor(options: any) {
+      constructorOptions.push(options);
+    }
+    connect() {
+      return Promise.resolve();
+    }
+    logout() {
+      return Promise.resolve();
+    }
+    on() {}
+  },
+}));
+
+describe('ImapService opportunistic STARTTLS opt-out', () => {
+  let service: ImapService;
+
+  const account = (allowStartTLS?: boolean): ImapAccount => ({
+    id: 'acct',
+    name: 'Shared host',
+    host: 'mail.example.com',
+    port: 143,
+    user: 'user@example.com',
+    password: 'secret',
+    tls: false,
+    ...(allowStartTLS !== undefined ? { allowStartTLS } : {}),
+  });
+
+  beforeEach(() => {
+    constructorOptions.length = 0;
+    service = new ImapService();
+  });
+
+  // imapflow opportunistically upgrades a non-`secure` connection via STARTTLS
+  // whenever the server advertises it, independent of `secure`/`tls`. That's
+  // correct for a normal STARTTLS-on-submission-port setup, but some shared
+  // mail hosts (e.g. DreamHost) advertise STARTTLS on a hostname covered only
+  // by a shared wildcard cert that doesn't match, so the upgrade fails cert
+  // validation even though the account was configured for a plain connection.
+  it('defaults to leaving the opportunistic STARTTLS upgrade enabled', async () => {
+    await service.connect(account());
+
+    expect(constructorOptions).toHaveLength(1);
+    expect(constructorOptions[0].doSTARTTLS).toBeUndefined();
+  });
+
+  it('passes doSTARTTLS: false to imapflow when allowStartTLS is false', async () => {
+    await service.connect(account(false));
+
+    expect(constructorOptions).toHaveLength(1);
+    expect(constructorOptions[0].doSTARTTLS).toBe(false);
+  });
+
+  it('applies the same opt-out to testConnection', async () => {
+    await service.testConnection(account(false));
+
+    expect(constructorOptions).toHaveLength(1);
+    expect(constructorOptions[0].doSTARTTLS).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #158

## Problem

`tls: false` only maps to imapflow's `secure: false` (no *implicit* TLS on connect) — it doesn't stop imapflow's opportunistic STARTTLS upgrade, which fires whenever the server's CAPABILITY response advertises STARTTLS and validates the cert against the dialed host regardless of `tls` (see #119's `tls: { host: account.host }`).

Concretely: DreamHost's shared mail hosting advertises STARTTLS on `mail.<customdomain>` but only carries a `*.dreamhost.com` cert. An account configured with `tls: false` for a plain connection on port 143 still gets opportunistically upgraded and then fails cert validation:

```
Hostname/IP does not match certificate's altnames: Host: mail.example.com. is not in the cert's altnames: DNS:*.dreamhost.com, DNS:dreamhost.com
```

## Why not just disable the upgrade globally

Opportunistic STARTTLS on a plain connection is correct and desirable for the common case (hostname cert matches). Disabling it unconditionally would silently downgrade those accounts to unencrypted connections without consent, so this needs to be an explicit per-account opt-out, not a change to what `tls: false` means.

## Fix

- New optional `allowStartTLS` field on `ImapAccount` (default `true`, preserving current behavior).
- `connect()` and `testConnection()` in `imap-service.ts` pass `doSTARTTLS: false` to `ImapFlow` when `allowStartTLS === false`.
- Wired into `imap_add_account` / `imap_update_account` input schemas, and surfaced (when `false`) in `imap_list_accounts` output.
- README updated for both tools.
- New test file `tests/imap-service-allow-starttls.test.ts`, mirroring the existing `imap-service-tls-host.test.ts` pattern (mocks `ImapFlow`, asserts on constructor options) — covers the default-on case, the opt-out on `connect()`, and the same opt-out on `testConnection()`.

## Testing

- `npx tsc --noEmit --skipLibCheck` — clean
- `npx vitest run` — 358 passed, 1 skipped (pre-existing skip, unrelated)
- Verified against a real DreamHost mailbox that previously failed with the cert-mismatch error above; connects successfully with `allowStartTLS: false`.