### PR TITLE
fix(email): validate outgoing attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,12 +547,23 @@ Once configured, the IMAP MCP server provides the following tools in Claude:
   - replyTo: Reply-to address (optional)
   - attachments: Array of attachments (optional)
     - filename: Attachment filename
-    - content: Base64 encoded content
-    - path: File path to attach
-    - contentType: MIME type
+    - content: Base64 encoded content; provide exactly one of `content` or `path`
+    - path: Readable local file path to attach; provide exactly one of `path` or `content`
+    - contentType: MIME type (defaults to `application/octet-stream`)
     - contentDisposition: "attachment" (default) or "inline" — use "inline" for images shown in the HTML body via cid:
     - cid: Content-ID for inline attachments; must match the `cid:` value used in an `<img src="cid:...">` tag in `html`
+  - dryRun: Validate attachments and compose MIME without sending or saving to Sent (optional, default: false)
   ```
+  Attachments are validated before SMTP is contacted. Invalid base64, unreadable
+  paths, missing filenames, ambiguous sources, and inline attachments without
+  `cid` fail fast. Successful sends and dry-runs return `attachmentCount` and
+  safe `attachmentDiagnostics`: filename, MIME type, size, source, disposition,
+  and cid. Diagnostics omit bytes, raw MIME, and local file paths.
+
+  For large files, upload with `imap_upload_file` first and pass its returned
+  local `path`; for inline images, set `contentDisposition: "inline"` and a
+  matching `cid`.
+
   After sending, a copy is saved to the account's Sent folder (unless
   `saveToSent` is disabled on the account). The folder is resolved via the
   account's `sentFolder` override → the server's `\Sent` SPECIAL-USE flag →

--- a/src/tools/email-tools.ts
+++ b/src/tools/email-tools.ts
@@ -5,11 +5,13 @@ import { SmtpService } from '../services/smtp-service.js';
 import { selectSearchFolders } from '../utils/search-folders.js';
 import { parseSerializedArray } from '../utils/array-input.js';
 import { mergeBcc } from '../utils/default-bcc.js';
-import type { EmailMessage, ImapAccount, SentSaveResult } from '../types/index.js';
+import type { EmailAttachment, EmailMessage, ImapAccount, SentSaveResult } from '../types/index.js';
 import { z } from 'zod';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
+import { constants as fsConstants } from 'fs';
+import { access, stat } from 'fs/promises';
 
 // Reusable, backward-compatible account selector. accountId stays accepted as
 // before; accountName and the single-account default are additive conveniences.
@@ -52,15 +54,119 @@ type AttachmentInput = {
   contentDisposition?: 'attachment' | 'inline';
   cid?: string;
 };
-const buildAttachments = (atts?: AttachmentInput[]) =>
-  atts?.map(att => ({
-    filename: att.filename,
-    content: att.content ? Buffer.from(att.content, 'base64') : undefined,
-    path: att.path,
-    contentType: att.contentType,
-    contentDisposition: att.contentDisposition,
-    cid: att.cid,
-  }));
+
+type NormalizedAttachments = {
+  attachments?: EmailAttachment[];
+  diagnostics: AttachmentDiagnostic[];
+};
+
+type AttachmentDiagnostic = {
+  index: number;
+  filename: string;
+  contentType: string;
+  size: number;
+  source: 'content' | 'path';
+  contentDisposition: 'attachment' | 'inline';
+  cid?: string;
+};
+
+const DEFAULT_ATTACHMENT_CONTENT_TYPE = 'application/octet-stream';
+
+function decodeStrictBase64(value: string, index: number): Buffer {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`Invalid attachment at index ${index}: content must be non-empty base64`);
+  }
+  if (normalized.length % 4 !== 0 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(normalized)) {
+    throw new Error(`Invalid attachment at index ${index}: content is not valid base64`);
+  }
+  return Buffer.from(normalized, 'base64');
+}
+
+export async function normalizeAttachments(atts?: AttachmentInput[]): Promise<NormalizedAttachments> {
+  if (!atts || atts.length === 0) {
+    return { attachments: undefined, diagnostics: [] };
+  }
+
+  const attachments: EmailAttachment[] = [];
+  const diagnostics: AttachmentDiagnostic[] = [];
+
+  for (const [index, att] of atts.entries()) {
+    const filename = basename(att.filename ?? '').trim();
+    if (!filename) {
+      throw new Error(`Invalid attachment at index ${index}: filename is required`);
+    }
+
+    const hasContent = att.content !== undefined;
+    const hasPath = att.path !== undefined;
+    if (hasContent === hasPath) {
+      throw new Error(`Invalid attachment at index ${index}: provide exactly one of content or path`);
+    }
+
+    const contentType = att.contentType || DEFAULT_ATTACHMENT_CONTENT_TYPE;
+    const contentDisposition = att.contentDisposition ?? 'attachment';
+    const cid = att.cid?.trim();
+    if (contentDisposition === 'inline' && !cid) {
+      throw new Error(`Invalid attachment at index ${index}: cid is required for inline attachments`);
+    }
+
+    if (hasContent) {
+      const content = decodeStrictBase64(att.content!, index);
+      attachments.push({
+        filename,
+        content,
+        contentType,
+        contentDisposition,
+        ...(cid ? { cid } : {}),
+      });
+      diagnostics.push({
+        index,
+        filename,
+        contentType,
+        size: content.length,
+        source: 'content',
+        contentDisposition,
+        ...(cid ? { cid } : {}),
+      });
+      continue;
+    }
+
+    const filePath = att.path?.trim();
+    if (!filePath) {
+      throw new Error(`Invalid attachment at index ${index}: path must be non-empty`);
+    }
+
+    let fileStat;
+    try {
+      fileStat = await stat(filePath);
+      if (!fileStat.isFile()) {
+        throw new Error('not a regular file');
+      }
+      await access(filePath, fsConstants.R_OK);
+    } catch {
+      throw new Error(`Invalid attachment at index ${index}: path is not a readable file. Check that the attachment path exists, points to a regular file, and is readable.`);
+    }
+
+    attachments.push({
+      filename,
+      path: filePath,
+      contentType,
+      contentDisposition,
+      ...(cid ? { cid } : {}),
+    });
+    diagnostics.push({
+      index,
+      filename,
+      contentType,
+      size: fileStat.size,
+      source: 'path',
+      contentDisposition,
+      ...(cid ? { cid } : {}),
+    });
+  }
+
+  return { attachments, diagnostics };
+}
 
 // Merge the account's defaultBcc with a per-call bcc (same pattern as
 // saveSentCopy honoring saveToSent / sentFolder on the account).
@@ -73,9 +179,9 @@ const resolveBcc = (
 // the three tool schemas (and their .describe() text) in sync.
 const attachmentSchema = z.object({
   filename: z.string().describe('Attachment filename'),
-  content: z.string().optional().describe('Base64 encoded content'),
-  path: z.string().optional().describe('File path to attach'),
-  contentType: z.string().optional().describe('MIME type'),
+  content: z.string().optional().describe('Base64 encoded content. Provide exactly one of content or path.'),
+  path: z.string().optional().describe('Readable local file path to attach. Provide exactly one of path or content; paths returned by imap_upload_file are accepted.'),
+  contentType: z.string().optional().describe('MIME type. Defaults to application/octet-stream when omitted.'),
   contentDisposition: z.enum(['attachment', 'inline']).optional().describe(
     'How the attachment is presented. Use "inline" for images referenced from the HTML body via cid: (e.g. a signature/footer banner); omit or use "attachment" for regular downloadable files.'
   ),
@@ -910,13 +1016,15 @@ export function emailTools(
       bcc: bccSchema,
       replyTo: z.string().optional().describe('Reply-to address'),
       attachments: z.array(attachmentSchema).optional().describe('Email attachments'),
+      dryRun: z.boolean().default(false).describe('Validate attachments and compose MIME without sending SMTP mail or saving a Sent copy. Use to diagnose attachment payloads safely before sending.'),
     }
-  }, async ({ accountId: rawAccountId, accountName, to, subject, text, html, body, cc, bcc, replyTo, attachments }) => {
+  }, async ({ accountId: rawAccountId, accountName, to, subject, text, html, body, cc, bcc, replyTo, attachments, dryRun }) => {
     const accountId = accountManager.resolveAccountId(rawAccountId, accountName);
     const account = await accountManager.getAccount(accountId);
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
     }
+    const normalizedAttachments = await normalizeAttachments(attachments as AttachmentInput[] | undefined);
 
     const emailComposer = {
       from: account.email || account.user,
@@ -927,8 +1035,24 @@ export function emailTools(
       cc,
       bcc: resolveBcc(account, bcc),
       replyTo,
-      attachments: buildAttachments(attachments as AttachmentInput[] | undefined),
+      attachments: normalizedAttachments.attachments,
     };
+
+    if (dryRun) {
+      await smtpService.composeRaw(account, emailComposer);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            success: true,
+            dryRun: true,
+            attachmentCount: normalizedAttachments.diagnostics.length,
+            attachmentDiagnostics: normalizedAttachments.diagnostics,
+            message: 'Email dry run completed successfully',
+          }, null, 2)
+        }]
+      };
+    }
 
     const { messageId, rawMessage } = await smtpService.sendEmail(accountId, account, emailComposer);
 
@@ -941,6 +1065,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           messageId,
+          attachmentCount: normalizedAttachments.diagnostics.length,
+          attachmentDiagnostics: normalizedAttachments.diagnostics,
           ...sentSaveFields(sentSave),
           message: `Email sent successfully${sentSaveSuffix(sentSave)}`,
         }, null, 2)
@@ -972,6 +1098,7 @@ export function emailTools(
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
     }
+    const normalizedAttachments = await normalizeAttachments(attachments as AttachmentInput[] | undefined);
 
     const emailComposer = {
       from: account.email || account.user,
@@ -984,7 +1111,7 @@ export function emailTools(
       replyTo,
       inReplyTo,
       references,
-      attachments: buildAttachments(attachments as AttachmentInput[] | undefined),
+      attachments: normalizedAttachments.attachments,
     };
 
     const rawMessage = await smtpService.composeRaw(account, emailComposer);
@@ -1005,6 +1132,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           folder: draftsFolder,
+          attachmentCount: normalizedAttachments.diagnostics.length,
+          attachmentDiagnostics: normalizedAttachments.diagnostics,
           message: `Draft saved to "${draftsFolder}"`,
         }, null, 2)
       }]
@@ -1031,6 +1160,7 @@ export function emailTools(
     if (!account) {
       throw new Error(`Account ${accountId} not found`);
     }
+    const normalizedAttachments = await normalizeAttachments(attachments as AttachmentInput[] | undefined);
 
     // Get original email (envelope only is needed here; skip body conversion)
     const originalEmail = await imapService.getEmailContent(accountId, folder, uid, { bodyFormat: 'text' });
@@ -1069,7 +1199,7 @@ export function emailTools(
       bcc: resolveBcc(account, bcc),
       inReplyTo: originalEmail.messageId,
       references: originalEmail.messageId,
-      attachments: buildAttachments(attachments as AttachmentInput[] | undefined),
+      attachments: normalizedAttachments.attachments,
     };
 
     const { messageId, rawMessage } = await smtpService.sendEmail(accountId, account, emailComposer);
@@ -1083,6 +1213,8 @@ export function emailTools(
         text: JSON.stringify({
           success: true,
           messageId,
+          attachmentCount: normalizedAttachments.diagnostics.length,
+          attachmentDiagnostics: normalizedAttachments.diagnostics,
           ...sentSaveFields(sentSave),
           message: `Reply sent successfully${sentSaveSuffix(sentSave)}`,
         }, null, 2)

--- a/tests/email-tools-send-attachment-diagnostics.test.ts
+++ b/tests/email-tools-send-attachment-diagnostics.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtemp, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { emailTools } from '../src/tools/email-tools.js';
+
+let sendEmailHandler: Function;
+
+const mockServer = {
+  registerTool: vi.fn((name: string, _schema: any, handler: Function) => {
+    if (name === 'imap_send_email') {
+      sendEmailHandler = handler;
+    }
+  }),
+};
+
+const account: any = {
+  id: 'acc1',
+  name: 'Test',
+  email: 'user@example.com',
+  user: 'user@example.com',
+};
+
+const mockImapService = {
+  appendToSentFolder: vi.fn(),
+};
+
+const mockAccountManager = {
+  resolveAccountId: (id: string) => id,
+  getAccount: vi.fn(async () => account),
+};
+
+const mockSmtpService = {
+  composeRaw: vi.fn(async () => Buffer.from('RAW')),
+  sendEmail: vi.fn(async () => ({ messageId: '<msg-1@example.com>', rawMessage: 'RAW' })),
+};
+
+const baseArgs = {
+  accountId: 'acc1',
+  to: 'rcpt@example.com',
+  subject: 'Hi',
+  text: 'Hello',
+};
+
+describe('imap_send_email attachment diagnostics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emailTools(
+      mockServer as any,
+      mockImapService as any,
+      mockAccountManager as any,
+      mockSmtpService as any,
+    );
+  });
+
+  it.each([
+    [
+      'both content and path',
+      { filename: 'report.pdf', content: Buffer.from('pdf').toString('base64'), path: '/tmp/report.pdf' },
+      'provide exactly one of content or path',
+    ],
+    ['invalid base64', { filename: 'report.pdf', content: 'not valid base64' }, 'content is not valid base64'],
+    [
+      'inline without cid',
+      { filename: 'logo.png', content: Buffer.from('png').toString('base64'), contentDisposition: 'inline' },
+      'cid is required for inline attachments',
+    ],
+  ])('fails before SMTP when attachment has %s', async (_name, attachment, message) => {
+    await expect(sendEmailHandler({ ...baseArgs, attachments: [attachment] }))
+      .rejects.toThrow(`Invalid attachment at index 0: ${message}`);
+    expect(mockSmtpService.sendEmail).not.toHaveBeenCalled();
+    expect(mockSmtpService.composeRaw).not.toHaveBeenCalled();
+    expect(mockImapService.appendToSentFolder).not.toHaveBeenCalled();
+  });
+
+  it('does not disclose supplied paths when a path attachment is unreadable', async () => {
+    const suppliedPath = join(tmpdir(), 'imap-mcp-private-path', 'missing-secret-report.pdf');
+
+    let thrown: unknown;
+    try {
+      await sendEmailHandler({
+        ...baseArgs,
+        attachments: [{ filename: 'report.pdf', path: suppliedPath }],
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toBe('Invalid attachment at index 0: path is not a readable file. Check that the attachment path exists, points to a regular file, and is readable.');
+    expect(message).not.toContain(suppliedPath);
+    expect(message).not.toContain('missing-secret-report.pdf');
+    expect(message).not.toContain('imap-mcp-private-path');
+    expect(mockSmtpService.sendEmail).not.toHaveBeenCalled();
+    expect(mockSmtpService.composeRaw).not.toHaveBeenCalled();
+    expect(mockImapService.appendToSentFolder).not.toHaveBeenCalled();
+  });
+
+  it('returns safe diagnostics after a successful send', async () => {
+    mockImapService.appendToSentFolder.mockResolvedValueOnce({ saved: true, folder: 'Sent' });
+
+    const result = await sendEmailHandler({
+      ...baseArgs,
+      attachments: [{
+        filename: '../report.pdf',
+        content: Buffer.from('pdf bytes').toString('base64'),
+        contentType: 'application/pdf',
+      }],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.attachmentCount).toBe(1);
+    expect(parsed.attachmentDiagnostics).toEqual([{
+      index: 0, filename: 'report.pdf', contentType: 'application/pdf',
+      size: 9, source: 'content', contentDisposition: 'attachment',
+    }]);
+    expect(JSON.stringify(parsed.attachmentDiagnostics)).not.toContain('pdf bytes');
+  });
+
+  it('dry-runs by composing MIME without sending or saving to Sent', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'imap-mcp-attachments-'));
+    const filePath = join(dir, 'invoice.pdf');
+    await writeFile(filePath, Buffer.from('file bytes'));
+
+    const result = await sendEmailHandler({
+      ...baseArgs,
+      dryRun: true,
+      attachments: [{
+        filename: 'invoice.pdf',
+        path: filePath,
+        contentType: 'application/pdf',
+      }],
+    });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(mockSmtpService.composeRaw).toHaveBeenCalledOnce();
+    expect(mockSmtpService.sendEmail).not.toHaveBeenCalled();
+    expect(mockImapService.appendToSentFolder).not.toHaveBeenCalled();
+    expect(parsed).toMatchObject({
+      success: true, dryRun: true, attachmentCount: 1,
+      attachmentDiagnostics: [{
+        index: 0, filename: 'invoice.pdf', contentType: 'application/pdf',
+        size: 10, source: 'path', contentDisposition: 'attachment',
+      }],
+    });
+    expect(JSON.stringify(parsed)).not.toContain(filePath);
+  });
+});

--- a/tests/smtp-service-attachments.test.ts
+++ b/tests/smtp-service-attachments.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { simpleParser } from 'mailparser';
+import { SmtpService } from '../src/services/smtp-service.js';
+import type { ImapAccount } from '../src/types/index.js';
+
+const account: ImapAccount = {
+  id: 'acc1',
+  name: 'Test',
+  host: 'imap.example.com',
+  port: 993,
+  user: 'user@example.com',
+  password: 'pw',
+  tls: true,
+  email: 'user@example.com',
+};
+
+describe('SmtpService.composeRaw attachments', () => {
+  const smtp = new SmtpService();
+
+  it.each([
+    ['report.pdf', 'application/pdf', Buffer.from('%PDF-1.4\n% test pdf\n')],
+    ['proposal.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', Buffer.from('PK\u0003\u0004docx fixture bytes')],
+  ])('includes %s filename, type, and bytes', async (filename, contentType, bytes) => {
+    const raw = await smtp.composeRaw(account, {
+      from: 'user@example.com',
+      to: 'rcpt@example.com',
+      subject: filename,
+      text: 'See attached',
+      attachments: [{ filename, content: bytes, contentType }],
+    });
+
+    const parsed = await simpleParser(raw);
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].filename).toBe(filename);
+    expect(parsed.attachments[0].contentType).toBe(contentType);
+    expect(parsed.attachments[0].content.equals(bytes)).toBe(true);
+  });
+
+  it('includes inline image disposition, cid, type, and bytes', async () => {
+    const pngBytes = Buffer.from('89504e470d0a1a0a', 'hex');
+    const raw = await smtp.composeRaw(account, {
+      from: 'user@example.com',
+      to: 'rcpt@example.com',
+      subject: 'Inline',
+      html: '<p>Logo <img src="cid:logo-image"></p>',
+      attachments: [{
+        filename: 'logo.png',
+        content: pngBytes,
+        contentType: 'image/png',
+        contentDisposition: 'inline',
+        cid: 'logo-image',
+      }],
+    });
+
+    const parsed = await simpleParser(raw);
+    expect(parsed.attachments).toHaveLength(1);
+    expect(parsed.attachments[0].filename).toBe('logo.png');
+    expect(parsed.attachments[0].contentType).toBe('image/png');
+    expect(parsed.attachments[0].contentDisposition).toBe('inline');
+    expect(parsed.attachments[0].contentId).toBe('<logo-image>');
+    expect(parsed.attachments[0].content.equals(pngBytes)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #160

## Summary

- Validates attachment inputs before SMTP activity, including base64, file readability, source exclusivity, and inline CID requirements.
- Adds safe attachment diagnostics and `dryRun` composition for `imap_send_email`.
- Documents canonical attachment payloads and adds MIME-level regression tests.

## Changes

| File | Change |
| --- | --- |
| `src/tools/email-tools.ts` | Normalize attachments, validate failures safely, add diagnostics and dry-run support. |
| `tests/email-tools-send-attachment-diagnostics.test.ts` | Cover validation errors, diagnostics, and dry-run behavior. |
| `tests/smtp-service-attachments.test.ts` | Cover MIME attachment composition. |
| `README.md` | Document payload contract, diagnostics, dry-run, and upload workflow. |

## Test plan

- [x] `npm run build`
- [x] `npm test` (36 files, 365 tests)
- [x] Sent and read back a DOCX attachment using a locally configured MCP instance.

## Notes

The target repository provides no `type:*` labels; this PR uses its available `bug` label.
